### PR TITLE
Remove lock icon, add click sound on puzzle selection

### DIFF
--- a/lib/screens/difficulty_screen.dart
+++ b/lib/screens/difficulty_screen.dart
@@ -184,23 +184,10 @@ class _DifficultyScreenState extends State<DifficultyScreen> {
     );
   }
 
-  /// Wraps [child] in an opacity + lock icon overlay when [locked] is true.
+  /// Wraps [child] in reduced opacity when [locked] is true.
   Widget _lockedOrButton({required bool locked, required Widget child}) {
     if (!locked) return child;
-    return Opacity(
-      opacity: 0.45,
-      child: Stack(
-        alignment: Alignment.center,
-        children: [
-          child,
-          const Icon(
-            Icons.lock_rounded,
-            color: Colors.white,
-            size: 32,
-          ),
-        ],
-      ),
-    );
+    return Opacity(opacity: 0.45, child: child);
   }
 
   Widget _buildPreview() {

--- a/lib/screens/image_selection_screen.dart
+++ b/lib/screens/image_selection_screen.dart
@@ -8,6 +8,7 @@ import 'package:lily_jigsaw_puzzle/models/puzzle_image.dart';
 import 'package:lily_jigsaw_puzzle/screens/difficulty_screen.dart';
 import 'package:lily_jigsaw_puzzle/screens/settings_screen.dart';
 import 'package:lily_jigsaw_puzzle/services/completion_service.dart';
+import 'package:lily_jigsaw_puzzle/services/sound_service.dart';
 import 'package:lily_jigsaw_puzzle/widgets/game_button.dart';
 import 'package:lily_jigsaw_puzzle/widgets/gradient_title.dart';
 
@@ -162,6 +163,7 @@ class _ImageCardState extends State<_ImageCard>
 
   void _onTap() {
     unawaited(_ctrl.reverse());
+    unawaited(SoundService().playClick());
     unawaited(Navigator.of(context).push(MaterialPageRoute<void>(
       builder: (_) => DifficultyScreen(
         selectedImage: widget.image,


### PR DESCRIPTION
## Summary

- Remove the lock icon overlay from locked difficulty buttons — reduced opacity alone is enough to communicate unavailability without cluttering the UI
- Play click sound when tapping a puzzle card on the image selection screen

## Test plan

- [x] Open difficulty screen for a puzzle with no completions — Medium and Hard should appear greyed-out with no icon
- [x] Tap a puzzle card on the selection screen — click sound plays
- [x] All 68 tests pass (`flutter test`)
- [x] No analysis issues (`flutter analyze`)

> Targets `stars-sounds-difficulty-unlock-refactor` — merge that PR first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)