### PR TITLE
feat: responsive mobile landscape support

### DIFF
--- a/lib/core/app_theme.dart
+++ b/lib/core/app_theme.dart
@@ -35,6 +35,9 @@ abstract final class AppColors {
   /// Orange — medium difficulty buttons.
   static const Color orange = Color(0xFFFFAB40);
 
+  /// Dark orange — shadow for orange buttons.
+  static const Color orangeShadow = Color(0xFFCC7722);
+
   /// Blue — navigation buttons.
   static const Color blue = Color(0xFF4D96FF);
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -36,6 +36,10 @@ class LocaleNotifier extends ChangeNotifier {
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky);
+  await SystemChrome.setPreferredOrientations([
+    DeviceOrientation.landscapeLeft,
+    DeviceOrientation.landscapeRight,
+  ]);
   final localeNotifier = await LocaleNotifier.load();
   runApp(JigsawApp(localeNotifier: localeNotifier));
 }

--- a/lib/screens/difficulty_screen.dart
+++ b/lib/screens/difficulty_screen.dart
@@ -39,7 +39,6 @@ class _DifficultyScreenState extends State<DifficultyScreen> {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
-
     final mediumLocked = _stars < 1;
     final hardLocked = _stars < 2;
 
@@ -49,99 +48,221 @@ class _DifficultyScreenState extends State<DifficultyScreen> {
         width: double.infinity,
         decoration: AppTheme.backgroundDecoration,
         child: SafeArea(
-          child: SingleChildScrollView(
-            child: Column(
-              children: [
-                const SizedBox(height: 14),
-
-                // Back button
-                Align(
-                  alignment: Alignment.centerLeft,
-                  child: Padding(
-                    padding: const EdgeInsets.only(left: 14),
-                    child: GameButton(
-                      label: l10n.back,
-                      icon: Icons.arrow_back_rounded,
-                      color: AppColors.mediumPurple,
-                      width: 120,
-                      height: 46,
-                      fontSize: 16,
-                      onPressed: () => Navigator.of(context).pop(),
-                    ),
-                  ),
-                ),
-
-                const SizedBox(height: 18),
-
-                // Image preview with decorative frame
-                _buildPreview(),
-
-                const SizedBox(height: 26),
-
-                // Section title
-                GradientTitle(text: l10n.pickDifficulty),
-
-                const SizedBox(height: 26),
-
-                // Easy — always unlocked
-                _DifficultyOption(
-                  description: l10n.easyDesc,
-                  button: GameButton(
-                    label: l10n.easy,
-                    color: AppColors.green,
-                    shadowColor: AppColors.greenShadow,
-                    width: 260,
-                    height: 64,
-                    fontSize: 22,
-                    onPressed: () => _go(context, 3),
-                  ),
-                ),
-                const SizedBox(height: 14),
-
-                // Medium — locked until ≥1 star
-                _DifficultyOption(
-                  description: l10n.mediumDesc,
-                  locked: mediumLocked,
-                  button: GameButton(
-                    label: l10n.medium,
-                    color: AppColors.orange,
-                    shadowColor: const Color(0xFFCC7722),
-                    width: 260,
-                    height: 64,
-                    fontSize: 22,
-                    onPressed: mediumLocked ? () {} : () => _go(context, 5),
-                  ),
-                ),
-                const SizedBox(height: 14),
-
-                // Hard — locked until ≥2 stars
-                _DifficultyOption(
-                  description: l10n.hardDesc,
-                  locked: hardLocked,
-                  button: GameButton(
-                    label: l10n.hard,
-                    color: AppColors.red,
-                    shadowColor: AppColors.redShadow,
-                    width: 260,
-                    height: 64,
-                    fontSize: 22,
-                    onPressed: hardLocked ? () {} : () => _go(context, 7),
-                  ),
-                ),
-
-                const SizedBox(height: 24),
-              ],
-            ),
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              final compact = constraints.maxHeight < 750;
+              return compact
+                  ? _buildCompactLayout(context, l10n, constraints, mediumLocked, hardLocked)
+                  : _buildNormalLayout(context, l10n, mediumLocked, hardLocked);
+            },
           ),
         ),
       ),
     );
   }
 
-  Widget _buildPreview() {
+  /// Standard vertical layout for tablets and larger screens.
+  Widget _buildNormalLayout(
+    BuildContext context,
+    AppLocalizations l10n,
+    bool mediumLocked,
+    bool hardLocked,
+  ) {
+    return Column(
+      children: [
+        const SizedBox(height: 14),
+
+        // Back button
+        Align(
+          alignment: Alignment.centerLeft,
+          child: Padding(
+            padding: const EdgeInsets.only(left: 14),
+            child: GameButton(
+              label: l10n.back,
+              icon: Icons.arrow_back_rounded,
+              color: AppColors.mediumPurple,
+              width: 120,
+              height: 46,
+              fontSize: 16,
+              onPressed: () => Navigator.of(context).pop(),
+            ),
+          ),
+        ),
+
+        const SizedBox(height: 18),
+
+        // Image preview with decorative frame
+        _buildThumbnailBox(width: 280, height: 200),
+
+        const SizedBox(height: 26),
+
+        GradientTitle(text: l10n.pickDifficulty),
+
+        const SizedBox(height: 26),
+
+        _DifficultyOption(
+          description: l10n.easyDesc,
+          button: GameButton(
+            label: l10n.easy,
+            color: AppColors.green,
+            shadowColor: AppColors.greenShadow,
+            width: 260,
+            height: 64,
+            fontSize: 22,
+            onPressed: () => _go(context, 3),
+          ),
+        ),
+        const SizedBox(height: 14),
+
+        _DifficultyOption(
+          description: l10n.mediumDesc,
+          locked: mediumLocked,
+          button: GameButton(
+            label: l10n.medium,
+            color: AppColors.orange,
+            shadowColor: const Color(0xFFCC7722),
+            width: 260,
+            height: 64,
+            fontSize: 22,
+            onPressed: mediumLocked ? () {} : () => _go(context, 5),
+          ),
+        ),
+        const SizedBox(height: 14),
+
+        _DifficultyOption(
+          description: l10n.hardDesc,
+          locked: hardLocked,
+          button: GameButton(
+            label: l10n.hard,
+            color: AppColors.red,
+            shadowColor: AppColors.redShadow,
+            width: 260,
+            height: 64,
+            fontSize: 22,
+            onPressed: hardLocked ? () {} : () => _go(context, 7),
+          ),
+        ),
+
+        const SizedBox(height: 24),
+      ],
+    );
+  }
+
+  /// Compact two-column layout for small landscape screens (phones).
+  ///
+  /// Shows the puzzle thumbnail on the left and difficulty buttons on the right.
+  Widget _buildCompactLayout(
+    BuildContext context,
+    AppLocalizations l10n,
+    BoxConstraints constraints,
+    bool mediumLocked,
+    bool hardLocked,
+  ) {
+    final btnHeight = (constraints.maxHeight * 0.18).clamp(38.0, 52.0);
+    final btnFontSize = (btnHeight * 0.38).clamp(13.0, 18.0);
+
+    return Column(
+      children: [
+        // Back button row
+        Padding(
+          padding: const EdgeInsets.only(left: 14, top: 8),
+          child: Align(
+            alignment: Alignment.centerLeft,
+            child: GameButton(
+              label: l10n.back,
+              icon: Icons.arrow_back_rounded,
+              color: AppColors.mediumPurple,
+              width: 100,
+              height: 36,
+              fontSize: 13,
+              onPressed: () => Navigator.of(context).pop(),
+            ),
+          ),
+        ),
+
+        // Thumbnail (left) + difficulty buttons (right)
+        Expanded(
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(14, 6, 14, 8),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                // Thumbnail fills left half
+                Expanded(
+                  child: Center(
+                    child: AspectRatio(
+                      aspectRatio: 4 / 3,
+                      child: _buildThumbnailBox(cornerRadius: 18),
+                    ),
+                  ),
+                ),
+
+                const SizedBox(width: 16),
+
+                // Title + difficulty buttons on right half
+                Expanded(
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      GradientTitle(text: l10n.pickDifficulty, fontSize: 18),
+                      const SizedBox(height: 8),
+                      _DifficultyOption(
+                        description: l10n.easyDesc,
+                        button: GameButton(
+                          label: l10n.easy,
+                          color: AppColors.green,
+                          shadowColor: AppColors.greenShadow,
+                          width: 180,
+                          height: btnHeight,
+                          fontSize: btnFontSize,
+                          onPressed: () => _go(context, 3),
+                        ),
+                      ),
+                      const SizedBox(height: 6),
+                      _DifficultyOption(
+                        description: l10n.mediumDesc,
+                        locked: mediumLocked,
+                        button: GameButton(
+                          label: l10n.medium,
+                          color: AppColors.orange,
+                          shadowColor: const Color(0xFFCC7722),
+                          width: 180,
+                          height: btnHeight,
+                          fontSize: btnFontSize,
+                          onPressed: mediumLocked ? () {} : () => _go(context, 5),
+                        ),
+                      ),
+                      const SizedBox(height: 6),
+                      _DifficultyOption(
+                        description: l10n.hardDesc,
+                        locked: hardLocked,
+                        button: GameButton(
+                          label: l10n.hard,
+                          color: AppColors.red,
+                          shadowColor: AppColors.redShadow,
+                          width: 180,
+                          height: btnHeight,
+                          fontSize: btnFontSize,
+                          onPressed: hardLocked ? () {} : () => _go(context, 7),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  /// Decorated thumbnail box. When [width] and [height] are omitted the
+  /// widget expands to fill its parent (use inside [AspectRatio] or [SizedBox]).
+  Widget _buildThumbnailBox({double? width, double? height, double cornerRadius = 24}) {
     return DecoratedBox(
       decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(24),
+        borderRadius: BorderRadius.circular(cornerRadius),
         boxShadow: [
           BoxShadow(
             color: Colors.black.withValues(alpha: 0.30),
@@ -156,11 +277,11 @@ class _DifficultyScreenState extends State<DifficultyScreen> {
         ],
       ),
       child: SizedBox(
-        width: 280,
-        height: 200,
+        width: width,
+        height: height,
         child: PuzzleThumbnail(
           assetPath: widget.selectedImage.assetPath,
-          cornerRadius: 24,
+          cornerRadius: cornerRadius,
         ),
       ),
     );
@@ -196,7 +317,7 @@ class _DifficultyOption extends StatelessWidget {
     return Column(
       children: [
         if (locked) Opacity(opacity: 0.45, child: button) else button,
-        const SizedBox(height: 6),
+        const SizedBox(height: 4),
         Text(
           description,
           textAlign: TextAlign.center,

--- a/lib/screens/difficulty_screen.dart
+++ b/lib/screens/difficulty_screen.dart
@@ -120,7 +120,7 @@ class _DifficultyScreenState extends State<DifficultyScreen> {
           button: GameButton(
             label: l10n.medium,
             color: AppColors.orange,
-            shadowColor: const Color(0xFFCC7722),
+            shadowColor: AppColors.orangeShadow,
             width: 260,
             height: 64,
             fontSize: 22,

--- a/lib/screens/difficulty_screen.dart
+++ b/lib/screens/difficulty_screen.dart
@@ -225,7 +225,7 @@ class _DifficultyScreenState extends State<DifficultyScreen> {
                         button: GameButton(
                           label: l10n.medium,
                           color: AppColors.orange,
-                          shadowColor: const Color(0xFFCC7722),
+                          shadowColor: AppColors.orangeShadow,
                           width: 180,
                           height: btnHeight,
                           fontSize: btnFontSize,

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -210,7 +210,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
       ('es', l10n.langSpanish),
     ];
 
-    return Padding(
+    return SingleChildScrollView(
       padding: const EdgeInsets.symmetric(horizontal: 24),
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -101,7 +101,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   ],
                 ),
               ),
-              const SizedBox(height: 30),
+              const SizedBox(height: 16),
               Expanded(
                 child: _unlocked
                     ? _buildSettingsPanel(context, l10n)
@@ -210,9 +210,10 @@ class _SettingsScreenState extends State<SettingsScreen> {
       ('es', l10n.langSpanish),
     ];
 
-    return SingleChildScrollView(
+    return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 24),
       child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
         children: [
           // Language section
           _buildSectionLabel(l10n.language),
@@ -260,11 +261,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
             }).toList(),
           ),
 
-          const SizedBox(height: 36),
+          const SizedBox(height: 24),
 
           // Reset progress section
           _buildSectionLabel(l10n.resetProgress),
-          const SizedBox(height: 14),
+          const SizedBox(height: 12),
           GameButton(
             label: l10n.resetProgress,
             icon: Icons.delete_sweep_rounded,
@@ -275,7 +276,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
             onPressed: () => unawaited(_resetProgress()),
           ),
           if (_resetDone) ...[
-            const SizedBox(height: 14),
+            const SizedBox(height: 12),
             Container(
               padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
               decoration: BoxDecoration(
@@ -292,8 +293,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
               ),
             ),
           ],
-
-          const SizedBox(height: 30),
         ],
       ),
     );

--- a/lib/screens/splash_screen.dart
+++ b/lib/screens/splash_screen.dart
@@ -77,6 +77,16 @@ class _SplashScreenState extends State<SplashScreen>
   Widget build(BuildContext context) {
     final size = MediaQuery.of(context).size;
 
+    // Scale content proportionally so it fits on small landscape screens.
+    // 440 is the natural content height at 1× (logo + gaps + title + dots).
+    final scale = (size.height / 440).clamp(0.0, 1.0);
+    final logoBox = 230.0 * scale;
+    final titleFontSize = 48.0 * scale;
+    final subtitleFontSize = 18.0 * scale;
+    final gapAfterLogo = 32.0 * scale;
+    final gapAfterTitle = 14.0 * scale;
+    final gapBeforeDots = 48.0 * scale;
+
     return Scaffold(
       body: Stack(
         children: [
@@ -101,31 +111,31 @@ class _SplashScreenState extends State<SplashScreen>
                       // Logo
                       Transform.scale(
                         scale: _scaleIn.value,
-                        child: const SizedBox(
-                          width: 230,
-                          height: 230,
+                        child: SizedBox(
+                          width: logoBox,
+                          height: logoBox,
                           child: CustomPaint(
-                            painter: LogoPainter(size: 200),
+                            painter: LogoPainter(size: logoBox * 0.87),
                           ),
                         ),
                       ),
 
-                      const SizedBox(height: 32),
+                      SizedBox(height: gapAfterLogo),
 
                       // Title with gradient + outline
-                      const GradientTitle(
+                      GradientTitle(
                         text: "Lily's Puzzle",
-                        fontSize: 48,
+                        fontSize: titleFontSize,
                         strokeWidth: 7,
                       ),
 
-                      const SizedBox(height: 14),
+                      SizedBox(height: gapAfterTitle),
 
                       // Subtitle
                       Text(
                         'Put the pieces together!',
                         style: TextStyle(
-                          fontSize: 18,
+                          fontSize: subtitleFontSize,
                           fontWeight: FontWeight.w700,
                           color: Colors.white.withValues(alpha: 0.92),
                           letterSpacing: 0.5,
@@ -139,7 +149,7 @@ class _SplashScreenState extends State<SplashScreen>
                         ),
                       ),
 
-                      const SizedBox(height: 48),
+                      SizedBox(height: gapBeforeDots),
 
                       // Loading dots
                       const _LoadingDots(),

--- a/lib/widgets/win_overlay.dart
+++ b/lib/widgets/win_overlay.dart
@@ -24,6 +24,21 @@ class WinOverlay extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
+    final screenH = MediaQuery.of(context).size.height;
+    final compact = screenH < 500;
+
+    final hPad = compact ? 24.0 : 40.0;
+    final vPad = compact ? 18.0 : 36.0;
+    final emojiFontSize = compact ? 40.0 : 72.0;
+    final titleFontSize = compact ? 24.0 : 34.0;
+    final subtitleFontSize = compact ? 13.0 : 16.0;
+    final btnHeight = compact ? 44.0 : 56.0;
+    final btnWidth = compact ? 190.0 : 220.0;
+    final gap = compact ? 6.0 : 10.0;
+    final subtitleGap = compact ? 4.0 : 8.0;
+    final btnGap = compact ? 16.0 : 28.0;
+    final btnSpacing = compact ? 8.0 : 12.0;
+
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
       onTap: () {},
@@ -37,7 +52,7 @@ class WinOverlay extends StatelessWidget {
         ),
         child: Center(
           child: Container(
-            padding: const EdgeInsets.symmetric(horizontal: 40, vertical: 36),
+            padding: EdgeInsets.symmetric(horizontal: hPad, vertical: vPad),
             decoration: BoxDecoration(
               borderRadius: BorderRadius.circular(28),
               gradient: const LinearGradient(
@@ -60,36 +75,36 @@ class WinOverlay extends StatelessWidget {
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
-                const Text('🎉', style: TextStyle(fontSize: 72)),
-                const SizedBox(height: 10),
-                GradientTitle(text: l10n.youDidIt, fontSize: 34),
-                const SizedBox(height: 8),
+                Text('🎉', style: TextStyle(fontSize: emojiFontSize)),
+                SizedBox(height: gap),
+                GradientTitle(text: l10n.youDidIt, fontSize: titleFontSize),
+                SizedBox(height: subtitleGap),
                 Text(
                   l10n.puzzleComplete,
                   style: TextStyle(
-                    fontSize: 16,
+                    fontSize: subtitleFontSize,
                     fontWeight: FontWeight.w600,
                     color: AppColors.deepPurple.withValues(alpha: 0.70),
                   ),
                 ),
-                const SizedBox(height: 28),
+                SizedBox(height: btnGap),
                 GameButton(
                   label: l10n.playAgain,
                   icon: Icons.replay_rounded,
                   color: AppColors.green,
                   shadowColor: AppColors.greenShadow,
-                  width: 220,
-                  height: 56,
+                  width: btnWidth,
+                  height: btnHeight,
                   onPressed: onPlayAgain,
                 ),
-                const SizedBox(height: 12),
+                SizedBox(height: btnSpacing),
                 GameButton(
                   label: l10n.newPuzzle,
                   icon: Icons.home_rounded,
                   color: AppColors.blue,
                   shadowColor: AppColors.blueShadow,
-                  width: 220,
-                  height: 56,
+                  width: btnWidth,
+                  height: btnHeight,
                   onPressed: onNewPuzzle,
                 ),
               ],

--- a/lib/widgets/win_overlay.dart
+++ b/lib/widgets/win_overlay.dart
@@ -37,7 +37,6 @@ class WinOverlay extends StatelessWidget {
     final gap = compact ? 6.0 : 10.0;
     final subtitleGap = compact ? 4.0 : 8.0;
     final btnGap = compact ? 16.0 : 28.0;
-    final layout = _WinOverlayLayout.of(screenH);
 
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
@@ -97,7 +96,7 @@ class WinOverlay extends StatelessWidget {
                   height: btnHeight,
                   onPressed: onPlayAgain,
                 ),
-                SizedBox(height: btnSpacing),
+                SizedBox(height: gap),
                 GameButton(
                   label: l10n.newPuzzle,
                   icon: Icons.home_rounded,

--- a/lib/widgets/win_overlay.dart
+++ b/lib/widgets/win_overlay.dart
@@ -37,7 +37,7 @@ class WinOverlay extends StatelessWidget {
     final gap = compact ? 6.0 : 10.0;
     final subtitleGap = compact ? 4.0 : 8.0;
     final btnGap = compact ? 16.0 : 28.0;
-    final btnSpacing = compact ? 8.0 : 12.0;
+    final layout = _WinOverlayLayout.of(screenH);
 
     return GestureDetector(
       behavior: HitTestBehavior.opaque,


### PR DESCRIPTION
## Summary

- Forces landscape orientation on startup (`SystemChrome.setPreferredOrientations`)
- **Difficulty screen**: removes `SingleChildScrollView`; screens < 750 px tall (phones) switch to a two-column layout — thumbnail on left, title + difficulty buttons on right. Larger screens (tablets) keep the original vertical layout
- **Settings screen**: removes `SingleChildScrollView`, uses a centered `Column` with tighter spacing that fits without overflow in landscape
- **Win overlay**: compact variant (smaller emoji, buttons, padding) on screens < 500 px tall to prevent overflow

## Test plan

- [x] `flutter test` — 240 tests pass
- [x] `flutter analyze` — no issues
- [x] `flutter build apk --debug` — builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)