### PR TITLE
chore: re-enable Flutter and Dart SDK updates via Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,18 +13,15 @@
   "rangeStrategy": "pin",
   "packageRules": [
     {
-      "description": "Flutter SDK updates",
+      "description": "Group Flutter and Dart SDK updates together for compatibility",
       "matchPackageNames": [
-        "flutter"
-      ],
-      "enabled": false
-    },
-    {
-      "description": "Dart SDK updates",
-      "matchPackageNames": [
+        "flutter",
         "dart"
       ],
-      "enabled": false
+      "groupName": "Flutter and Dart SDK",
+      "schedule": [
+        "on sunday"
+      ]
     },
     {
       "description": "Group pub.dev dependency updates",


### PR DESCRIPTION
Group Flutter and Dart into a single Sunday PR to ensure they always update together, preventing version mismatches between workflow files.