### PR TITLE
feat: daily puzzle streak counter

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/003-hint-feedback-effects"
+  "feature_directory": "specs/004-daily-puzzle-streak"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,5 +213,5 @@ When running in GitHub Actions:
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/003-hint-feedback-effects/plan.md
+at specs/004-daily-puzzle-streak/plan.md
 <!-- SPECKIT END -->

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 80%
+    patch:
+      default:
+        target: 80%
+
+ignore:
+  - "lib/l10n/app_localizations*.dart"
+  - "lib/l10n/app_localizations.dart"

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -52,5 +52,17 @@
   "hintsSection": "Hinweise",
   "hintsImmediate": "Immer aktiv",
   "hintsDelayLabel": "Entsperrzeit (Sekunden)",
-  "hintsDelayError": "Bitte eine positive Zahl eingeben"
+  "hintsDelayError": "Bitte eine positive Zahl eingeben",
+  "streakDays": "🔥 {count} Tage am Stück",
+  "@streakDays": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "streakBest": "Bestleistung: {count} Tage",
+  "@streakBest": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -52,5 +52,17 @@
   "hintsSection": "Hints",
   "hintsImmediate": "Always Active",
   "hintsDelayLabel": "Unlock delay (seconds)",
-  "hintsDelayError": "Enter a positive number"
+  "hintsDelayError": "Enter a positive number",
+  "streakDays": "🔥 {count} Day Streak",
+  "@streakDays": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "streakBest": "Best: {count} days",
+  "@streakBest": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  }
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -52,5 +52,17 @@
   "hintsSection": "Pistas",
   "hintsImmediate": "Siempre activo",
   "hintsDelayLabel": "Tiempo de desbloqueo (segundos)",
-  "hintsDelayError": "Ingresa un número positivo"
+  "hintsDelayError": "Ingresa un número positivo",
+  "streakDays": "🔥 {count} días seguidos",
+  "@streakDays": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "streakBest": "Récord: {count} días",
+  "@streakBest": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -347,6 +347,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Enter a positive number'**
   String get hintsDelayError;
+
+  /// No description provided for @streakDays.
+  ///
+  /// In en, this message translates to:
+  /// **'🔥 {count} Day Streak'**
+  String streakDays(int count);
+
+  /// No description provided for @streakBest.
+  ///
+  /// In en, this message translates to:
+  /// **'Best: {count} days'**
+  String streakBest(int count);
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -134,4 +134,14 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get hintsDelayError => 'Bitte eine positive Zahl eingeben';
+
+  @override
+  String streakDays(int count) {
+    return '🔥 $count Tage am Stück';
+  }
+
+  @override
+  String streakBest(int count) {
+    return 'Bestleistung: $count Tage';
+  }
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -134,4 +134,14 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get hintsDelayError => 'Enter a positive number';
+
+  @override
+  String streakDays(int count) {
+    return '🔥 $count Day Streak';
+  }
+
+  @override
+  String streakBest(int count) {
+    return 'Best: $count days';
+  }
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -134,4 +134,14 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get hintsDelayError => 'Ingresa un número positivo';
+
+  @override
+  String streakDays(int count) {
+    return '🔥 $count días seguidos';
+  }
+
+  @override
+  String streakBest(int count) {
+    return 'Récord: $count días';
+  }
 }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -134,4 +134,14 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get hintsDelayError => 'Wpisz liczbę większą od zera';
+
+  @override
+  String streakDays(int count) {
+    return '🔥 $count dni z rzędu';
+  }
+
+  @override
+  String streakBest(int count) {
+    return 'Rekord: $count dni';
+  }
 }

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -52,5 +52,17 @@
   "hintsSection": "Podpowiedzi",
   "hintsImmediate": "Zawsze aktywne",
   "hintsDelayLabel": "Czas odblokowania (sekundy)",
-  "hintsDelayError": "Wpisz liczbę większą od zera"
+  "hintsDelayError": "Wpisz liczbę większą od zera",
+  "streakDays": "🔥 {count} dni z rzędu",
+  "@streakDays": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "streakBest": "Rekord: {count} dni",
+  "@streakBest": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  }
 }

--- a/lib/models/streak_record.dart
+++ b/lib/models/streak_record.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/foundation.dart';
+
+/// Immutable snapshot of a user's consecutive-day puzzle completion streak.
+@immutable
+class StreakRecord {
+  /// Creates a [StreakRecord].
+  ///
+  /// Asserts that [currentStreak] ≥ 0, [longestStreak] ≥ 0, and
+  /// [longestStreak] ≥ [currentStreak].
+  const StreakRecord({
+    required this.currentStreak,
+    required this.longestStreak,
+    this.lastCompletionDate,
+  })  : assert(currentStreak >= 0, 'currentStreak must be non-negative'),
+        assert(longestStreak >= 0, 'longestStreak must be non-negative'),
+        assert(
+          longestStreak >= currentStreak,
+          'longestStreak must be >= currentStreak',
+        );
+
+  /// Returns the initial [StreakRecord] before any puzzle has ever been completed.
+  factory StreakRecord.initial() =>
+      const StreakRecord(currentStreak: 0, longestStreak: 0);
+
+  /// Number of consecutive calendar days on which at least one puzzle was completed,
+  /// ending on [lastCompletionDate]. Zero before the first puzzle is completed.
+  final int currentStreak;
+
+  /// All-time highest value of [currentStreak]. Never decremented.
+  final int longestStreak;
+
+  /// ISO 8601 date (`YYYY-MM-DD`, device local time zone) of the most recent
+  /// puzzle completion, or `null` when no puzzle has ever been completed.
+  final String? lastCompletionDate;
+
+  /// Returns a copy of this record with the specified fields overridden.
+  StreakRecord copyWith({
+    int? currentStreak,
+    int? longestStreak,
+    String? lastCompletionDate,
+  }) =>
+      StreakRecord(
+        currentStreak: currentStreak ?? this.currentStreak,
+        longestStreak: longestStreak ?? this.longestStreak,
+        lastCompletionDate: lastCompletionDate ?? this.lastCompletionDate,
+      );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is StreakRecord &&
+          other.currentStreak == currentStreak &&
+          other.longestStreak == longestStreak &&
+          other.lastCompletionDate == lastCompletionDate;
+
+  @override
+  int get hashCode =>
+      Object.hash(currentStreak, longestStreak, lastCompletionDate);
+}

--- a/lib/screens/game_board_view.dart
+++ b/lib/screens/game_board_view.dart
@@ -7,6 +7,7 @@ import 'package:lily_jigsaw_puzzle/core/widgets/panel_backgrounds.dart';
 import 'package:lily_jigsaw_puzzle/l10n/app_localizations.dart';
 import 'package:lily_jigsaw_puzzle/models/game_state.dart';
 import 'package:lily_jigsaw_puzzle/models/hint_slot_state.dart';
+import 'package:lily_jigsaw_puzzle/models/streak_record.dart';
 import 'package:lily_jigsaw_puzzle/painters/all_pieces_painter.dart';
 import 'package:lily_jigsaw_puzzle/painters/board_grid_painter.dart';
 import 'package:lily_jigsaw_puzzle/painters/board_shadow_painter.dart';
@@ -36,6 +37,7 @@ class GameBoardView extends StatelessWidget {
     required this.onPlayAgain,
     required this.onNewPuzzle,
     required this.onHint,
+    this.streakRecord,
     this.onPanStart,
     this.onPanUpdate,
     this.onPanEnd,
@@ -105,6 +107,10 @@ class GameBoardView extends StatelessWidget {
   /// When `true`, keeps the hint area in the widget tree even if
   /// [currentHintSlot] is `null` (e.g. while the exit animation is playing).
   final bool showHintArea;
+
+  /// Streak data to display on [WinOverlay] after a puzzle is won.
+  /// `null` until the streak service has recorded the completion.
+  final StreakRecord? streakRecord;
 
   @override
   Widget build(BuildContext context) {
@@ -176,6 +182,7 @@ class GameBoardView extends StatelessWidget {
           WinOverlay(
             onPlayAgain: onPlayAgain,
             onNewPuzzle: onNewPuzzle,
+            streakRecord: streakRecord,
           ),
       ],
     );

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -12,12 +12,15 @@ import 'package:lily_jigsaw_puzzle/models/game_state.dart';
 import 'package:lily_jigsaw_puzzle/models/hint_slot_state.dart';
 import 'package:lily_jigsaw_puzzle/models/puzzle_image.dart';
 import 'package:lily_jigsaw_puzzle/models/puzzle_piece.dart';
+import 'package:lily_jigsaw_puzzle/models/streak_record.dart';
 import 'package:lily_jigsaw_puzzle/painters/confetti_painter.dart';
 import 'package:lily_jigsaw_puzzle/painters/jigsaw_piece_painter.dart';
 import 'package:lily_jigsaw_puzzle/screens/game_board_view.dart';
 import 'package:lily_jigsaw_puzzle/services/completion_service.dart';
 import 'package:lily_jigsaw_puzzle/services/hint_settings_service.dart';
 import 'package:lily_jigsaw_puzzle/services/sound_service.dart';
+import 'package:lily_jigsaw_puzzle/services/streak_service.dart';
+
 
 class GameScreen extends StatefulWidget {
 
@@ -69,6 +72,9 @@ class _GameScreenState extends State<GameScreen>
   late AnimationController _confettiController;
   List<ConfettiParticle> _confettiParticles = const [];
   bool _showWinOverlay = false;
+
+  // Streak data populated by StreakService when the puzzle is won.
+  StreakRecord? _streakRecord;
 
   // Hint glow animation
   late AnimationController _hintController;
@@ -538,6 +544,7 @@ class _GameScreenState extends State<GameScreen>
       confettiParticles: _confettiParticles,
       confettiController: _confettiController,
       showWinOverlay: _showWinOverlay,
+      streakRecord: _streakRecord,
       onBack: () => Navigator.of(context).popUntil((r) => r.isFirst),
       onPlayAgain: _restartGame,
       onNewPuzzle: () => Navigator.of(context).popUntil((r) => r.isFirst),
@@ -577,6 +584,7 @@ class _GameScreenState extends State<GameScreen>
       _assembledPositions = null;
       _scatterTargets = null;
       _showWinOverlay = false;
+      _streakRecord = null;
       _showingHintArea = true;
     });
     WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -589,6 +597,8 @@ class _GameScreenState extends State<GameScreen>
       widget.selectedImage.uuid,
       widget.difficultyStars,
     );
+    final streak = await StreakService().recordPuzzleCompletion();
+    if (mounted) setState(() => _streakRecord = streak);
   }
 
   /// If the piece centre has gone outside the visible screen bounds,

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -21,7 +21,6 @@ import 'package:lily_jigsaw_puzzle/services/hint_settings_service.dart';
 import 'package:lily_jigsaw_puzzle/services/sound_service.dart';
 import 'package:lily_jigsaw_puzzle/services/streak_service.dart';
 
-
 class GameScreen extends StatefulWidget {
 
   const GameScreen({

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -10,6 +10,7 @@ import 'package:lily_jigsaw_puzzle/screens/difficulty_sliders_section.dart';
 import 'package:lily_jigsaw_puzzle/services/completion_service.dart';
 import 'package:lily_jigsaw_puzzle/services/difficulty_settings_service.dart';
 import 'package:lily_jigsaw_puzzle/services/hint_settings_service.dart';
+import 'package:lily_jigsaw_puzzle/services/streak_service.dart';
 import 'package:lily_jigsaw_puzzle/widgets/game_button.dart';
 import 'package:lily_jigsaw_puzzle/widgets/gradient_title.dart';
 
@@ -85,6 +86,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
   Future<void> _resetProgress() async {
     await CompletionService().resetAll();
+    await StreakService().resetAll();
     if (mounted) setState(() => _resetDone = true);
   }
 

--- a/lib/services/streak_service.dart
+++ b/lib/services/streak_service.dart
@@ -1,0 +1,108 @@
+import 'dart:math';
+
+import 'package:lily_jigsaw_puzzle/models/streak_record.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Persists and transitions a user's consecutive-day puzzle completion streak.
+///
+/// Streak data is stored via [SharedPreferences] using three keys under the
+/// `streak_` namespace.
+class StreakService {
+  /// Creates a [StreakService].
+  ///
+  /// [clock] defaults to [DateTime.now]. Inject a custom clock in tests to
+  /// control the current date without any mocking framework.
+  StreakService({DateTime Function()? clock}) : _clock = clock ?? DateTime.now;
+
+  static const _kCurrentKey = 'streak_current';
+  static const _kLongestKey = 'streak_longest';
+  static const _kLastDateKey = 'streak_last_date';
+
+  final DateTime Function() _clock;
+
+  /// Returns the current [StreakRecord] from persistent storage.
+  ///
+  /// Returns [StreakRecord.initial()] when no streak has been recorded yet.
+  Future<StreakRecord> getStreak() async {
+    final prefs = await SharedPreferences.getInstance();
+    return StreakRecord(
+      currentStreak: prefs.getInt(_kCurrentKey) ?? 0,
+      longestStreak: prefs.getInt(_kLongestKey) ?? 0,
+      lastCompletionDate: prefs.getString(_kLastDateKey),
+    );
+  }
+
+  /// Records a puzzle completion for today and returns the updated [StreakRecord].
+  ///
+  /// Transition rules applied against the current device date:
+  /// - No prior completion → streak becomes 1.
+  /// - Same-day completion → record is unchanged (idempotent).
+  /// - Consecutive-day completion → streak increments by 1.
+  /// - Gap of 2+ days → streak resets to 1; [StreakRecord.longestStreak] is preserved.
+  Future<StreakRecord> recordPuzzleCompletion() async {
+    final existing = await getStreak();
+    final today = _toDateString(_clock());
+    final next = _transition(existing, today);
+    if (next != existing) {
+      await _persist(next);
+    }
+    return next;
+  }
+
+  /// Removes all streak data from persistent storage.
+  Future<void> resetAll() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_kCurrentKey);
+    await prefs.remove(_kLongestKey);
+    await prefs.remove(_kLastDateKey);
+  }
+
+  StreakRecord _transition(StreakRecord existing, String today) {
+    final last = existing.lastCompletionDate;
+
+    if (last == null) {
+      return StreakRecord(
+        currentStreak: 1,
+        longestStreak: max(1, existing.longestStreak),
+        lastCompletionDate: today,
+      );
+    }
+
+    if (last == today) {
+      return existing;
+    }
+
+    if (last == _yesterday(today)) {
+      final newCurrent = existing.currentStreak + 1;
+      return StreakRecord(
+        currentStreak: newCurrent,
+        longestStreak: max(newCurrent, existing.longestStreak),
+        lastCompletionDate: today,
+      );
+    }
+
+    return StreakRecord(
+      currentStreak: 1,
+      longestStreak: existing.longestStreak,
+      lastCompletionDate: today,
+    );
+  }
+
+  Future<void> _persist(StreakRecord record) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_kCurrentKey, record.currentStreak);
+    await prefs.setInt(_kLongestKey, record.longestStreak);
+    if (record.lastCompletionDate != null) {
+      await prefs.setString(_kLastDateKey, record.lastCompletionDate!);
+    }
+  }
+
+  String _toDateString(DateTime dt) =>
+      '${dt.year.toString().padLeft(4, '0')}'
+      '-${dt.month.toString().padLeft(2, '0')}'
+      '-${dt.day.toString().padLeft(2, '0')}';
+
+  String _yesterday(String isoDate) => _toDateString(
+        DateTime.parse(isoDate).subtract(const Duration(days: 1)),
+      );
+}

--- a/lib/widgets/win_overlay.dart
+++ b/lib/widgets/win_overlay.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:lily_jigsaw_puzzle/core/app_theme.dart';
 import 'package:lily_jigsaw_puzzle/l10n/app_localizations.dart';
+import 'package:lily_jigsaw_puzzle/models/streak_record.dart';
 import 'package:lily_jigsaw_puzzle/widgets/game_button.dart';
 import 'package:lily_jigsaw_puzzle/widgets/gradient_title.dart';
 
@@ -12,6 +13,7 @@ class WinOverlay extends StatelessWidget {
   const WinOverlay({
     required this.onPlayAgain,
     required this.onNewPuzzle,
+    this.streakRecord,
     super.key,
   });
 
@@ -20,6 +22,10 @@ class WinOverlay extends StatelessWidget {
 
   /// Called when the player taps "New Puzzle".
   final VoidCallback onNewPuzzle;
+
+  /// Streak data to display after a puzzle is won.
+  /// When `null` or [StreakRecord.currentStreak] is zero, no streak section is shown.
+  final StreakRecord? streakRecord;
 
   @override
   Widget build(BuildContext context) {
@@ -84,6 +90,25 @@ class WinOverlay extends StatelessWidget {
                     color: AppColors.deepPurple.withValues(alpha: 0.70),
                   ),
                 ),
+                if (streakRecord != null && streakRecord!.currentStreak > 0) ...[
+                  SizedBox(height: subtitleGap),
+                  Text(
+                    l10n.streakDays(streakRecord!.currentStreak),
+                    style: TextStyle(
+                      fontSize: compact ? 16.0 : 20.0,
+                      fontWeight: FontWeight.w800,
+                      color: AppColors.hotPink,
+                    ),
+                  ),
+                  Text(
+                    l10n.streakBest(streakRecord!.longestStreak),
+                    style: TextStyle(
+                      fontSize: compact ? 12.0 : 14.0,
+                      fontWeight: FontWeight.w600,
+                      color: AppColors.deepPurple.withValues(alpha: 0.60),
+                    ),
+                  ),
+                ],
                 SizedBox(height: btnGap),
                 GameButton(
                   label: l10n.playAgain,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -37,50 +37,50 @@ packages:
     dependency: transitive
     description:
       name: audioplayers_android
-      sha256: f5ff5b15620fbab8cb0849e9636c48e2b96c3f0f71723bbbe2ad3c761b205f05
+      sha256: "60a6728277228413a85755bd3ffd6fab98f6555608923813ce383b190a360605"
       url: "https://pub.dev"
     source: hosted
-    version: "5.3.0"
+    version: "5.2.1"
   audioplayers_darwin:
     dependency: transitive
     description:
       name: audioplayers_darwin
-      sha256: "1ca553add991384ecf421b9569da850f3ab2472ffb83f6970b0416365abc51be"
+      sha256: c994b3bb3a921e4904ac40e013fbc94488e824fd7c1de6326f549943b0b44a91
       url: "https://pub.dev"
     source: hosted
-    version: "6.5.0"
+    version: "6.4.0"
   audioplayers_linux:
     dependency: transitive
     description:
       name: audioplayers_linux
-      sha256: "15178b726b7cdee5364d0463c8d445630c4e0fb7d26612b73c767e7d25de9417"
+      sha256: f75bce1ce864170ef5e6a2c6a61cd3339e1a17ce11e99a25bae4474ea491d001
       url: "https://pub.dev"
     source: hosted
-    version: "4.3.0"
+    version: "4.2.1"
   audioplayers_platform_interface:
     dependency: transitive
     description:
       name: audioplayers_platform_interface
-      sha256: "765f6f0e6dca55cb471c9483fc77700564b3484d19198aca4ebb5147c6c85acb"
+      sha256: "0e2f6a919ab56d0fec272e801abc07b26ae7f31980f912f24af4748763e5a656"
       url: "https://pub.dev"
     source: hosted
-    version: "7.2.0"
+    version: "7.1.1"
   audioplayers_web:
     dependency: transitive
     description:
       name: audioplayers_web
-      sha256: ae1e0103c865a03e273f6d13d97b93f5595eac09915729cd5e37ef96e2857319
+      sha256: "24a6f258062bd7da8cb2157e83fccb9816a08dd306cbaaa24f9813d071470545"
       url: "https://pub.dev"
     source: hosted
-    version: "5.3.0"
+    version: "5.2.1"
   audioplayers_windows:
     dependency: transitive
     description:
       name: audioplayers_windows
-      sha256: d0690f33b1443ee89632126861a997db33dc90f3af54aef305dfb977bc580f2c
+      sha256: "95f875a96c88c3dbbcb608d4f8288e300b0113d256a81d0b3197fcc18f0dc91a"
       url: "https://pub.dev"
     source: hosted
-    version: "4.4.0"
+    version: "4.3.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -353,10 +353,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   objective_c:
     dependency: transitive
     description:
@@ -489,10 +489,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: "93ae5884a9df5d3bb696825bceb3a17590754548b5d740eba51500afc8d088f5"
+      sha256: e8d4762b1e2e8578fc4d0fd548cebf24afd24f49719c08974df92834565e2c53
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.26"
+    version: "2.4.23"
   shared_preferences_foundation:
     dependency: transitive
     description:
@@ -574,10 +574,10 @@ packages:
     dependency: transitive
     description:
       name: synchronized
-      sha256: "93b153dcb6a26dcddee6ca087dd634b53e38c10b5aa163e8e49501a776456153"
+      sha256: "63896c27e81b28f8cb4e69ead0d3e8f03f1d1e5fc531a3e579cabed6a2c7c9e5"
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.1"
+    version: "3.4.0+1"
   term_glyph:
     dependency: transitive
     description:
@@ -590,10 +590,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.10"
   typed_data:
     dependency: transitive
     description:
@@ -667,5 +667,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.12.0 <4.0.0"
-  flutter: ">=3.44.0"
+  dart: ">=3.11.1 <4.0.0"
+  flutter: ">=3.38.4"

--- a/specs/004-daily-puzzle-streak/checklists/requirements.md
+++ b/specs/004-daily-puzzle-streak/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Daily Puzzle Streak
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-27
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Spec is ready for `/speckit-clarify` or `/speckit-plan`.
+- Display location (beyond win overlay) is intentionally deferred to planning per Assumptions section.

--- a/specs/004-daily-puzzle-streak/data-model.md
+++ b/specs/004-daily-puzzle-streak/data-model.md
@@ -1,0 +1,150 @@
+# Data Model: Daily Puzzle Streak
+
+**Feature**: 004-daily-puzzle-streak | **Date**: 2026-06-27
+
+---
+
+## StreakRecord (immutable value object)
+
+**File**: `lib/models/streak_record.dart`
+
+**Purpose**: Carries the complete streak state as a single, immutable snapshot. All fields are final. No business logic lives here — pure data.
+
+| Field | Type | Constraints | Description |
+|-------|------|-------------|-------------|
+| `currentStreak` | `int` | ≥ 0 | Number of consecutive calendar days on which at least one puzzle was completed, ending on `lastCompletionDate`. Zero only before the user has ever completed a puzzle. |
+| `longestStreak` | `int` | ≥ `currentStreak` | All-time highest value of `currentStreak`. Never decremented. |
+| `lastCompletionDate` | `String?` | `YYYY-MM-DD` or `null` | ISO 8601 date of the most recent puzzle completion in the device local time zone. `null` when the user has never completed a puzzle. |
+
+**Validation invariants** (enforced by constructor assert):
+- `currentStreak >= 0`
+- `longestStreak >= 0`
+- `longestStreak >= currentStreak`
+
+**Key methods**:
+- `StreakRecord.initial()` — factory returning `StreakRecord(currentStreak: 0, longestStreak: 0, lastCompletionDate: null)`, i.e. the state before any puzzle is ever completed
+- `copyWith({int? currentStreak, int? longestStreak, String? lastCompletionDate})` — returns a new record with overridden fields
+
+---
+
+## StreakService
+
+**File**: `lib/services/streak_service.dart`
+
+**Purpose**: Sole owner of streak persistence and transition logic. Reads/writes three `SharedPreferences` keys. Follows the exact same structural pattern as `CompletionService`.
+
+### SharedPreferences keys (private constants)
+
+| Constant | Key string | Type |
+|----------|------------|------|
+| `_kCurrentKey` | `'streak_current'` | `int` |
+| `_kLongestKey` | `'streak_longest'` | `int` |
+| `_kLastDateKey` | `'streak_last_date'` | `String` |
+
+### Constructor
+
+```
+StreakService({ DateTime Function()? clock })
+```
+
+`clock` defaults to `() => DateTime.now()`. Injected in tests to control the current date without any mocking framework.
+
+### Public API
+
+```
+Future<StreakRecord> getStreak() async
+```
+Reads all three keys from `SharedPreferences` and returns the current `StreakRecord`. Returns `StreakRecord.initial()` if no keys exist yet.
+
+```
+Future<StreakRecord> recordPuzzleCompletion() async
+```
+Computes the new `StreakRecord` by applying streak transition logic (see below) against `clock()`, persists all three keys, and returns the updated record.
+
+```
+Future<void> resetAll() async
+```
+Removes all three keys. Used by the settings "Reset Progress" flow and tests.
+
+### Streak transition logic (pure, inside `recordPuzzleCompletion`)
+
+```
+today = toDateString(clock())          // YYYY-MM-DD
+existing = await getStreak()
+
+if existing.lastCompletionDate == null:
+  next = StreakRecord(currentStreak: 1,
+                     longestStreak: max(1, existing.longestStreak),
+                     lastCompletionDate: today)
+
+elif existing.lastCompletionDate == today:
+  next = existing (no change, idempotent)
+
+elif existing.lastCompletionDate == yesterday(today):
+  newCurrent = existing.currentStreak + 1
+  next = StreakRecord(currentStreak: newCurrent,
+                     longestStreak: max(newCurrent, existing.longestStreak),
+                     lastCompletionDate: today)
+
+else:  // gap of 2+ days
+  next = StreakRecord(currentStreak: 1,
+                     longestStreak: existing.longestStreak,
+                     lastCompletionDate: today)
+
+persist(next)
+return next
+```
+
+**Helper**: `String _toDateString(DateTime dt)` formats as `'${dt.year.toString().padLeft(4,'0')}-${dt.month.toString().padLeft(2,'0')}-${dt.day.toString().padLeft(2,'0')}'`.
+
+**Helper**: `String _yesterday(String isoDate)` subtracts one day using `DateTime.parse(isoDate).subtract(const Duration(days: 1))` and re-formats.
+
+---
+
+## Modified: WinOverlay
+
+**File**: `lib/widgets/win_overlay.dart`
+
+**Change**: Add `final StreakRecord? streakRecord;` as an optional named constructor parameter (defaults to `null`). When non-null and `streakRecord.currentStreak > 0`, render a streak section between the subtitle text and the action buttons. Existing constructor callers that omit `streakRecord` continue to work unchanged.
+
+**Streak section layout** (when streak is shown):
+- Fire emoji + current streak count + localised "Day Streak" label — prominent, child-friendly
+- Localised "Best:" label + longest streak count — smaller, secondary
+
+**New localisation keys** (added to all four ARB files):
+
+| Key | EN value | Notes |
+|-----|----------|-------|
+| `streakDays` | `"🔥 {count} Day Streak"` | `count` placeholder (int) |
+| `streakBest` | `"Best: {count} days"` | `count` placeholder (int) |
+
+---
+
+## Modified: GameScreen
+
+**File**: `lib/screens/game_screen.dart`
+
+**Change**: Add `StreakRecord? _streakRecord` field. In `_recordCompletion()`, call `StreakService().recordPuzzleCompletion()` and store the result in `_streakRecord` (via `setState`). Pass `_streakRecord` to the `WinOverlay` constructor.
+
+No change to `GameState`, `CompletionService`, or any other existing file.
+
+---
+
+## State Transitions Diagram
+
+```
+[Never played]
+  lastCompletionDate = null, currentStreak = 0
+
+  → complete puzzle on Day 1
+  lastCompletionDate = "2026-06-27", currentStreak = 1, longestStreak = 1
+
+  → complete puzzle again on Day 1 (same day)
+  ← no change (idempotent)
+
+  → complete puzzle on Day 2 (consecutive)
+  lastCompletionDate = "2026-06-28", currentStreak = 2, longestStreak = 2
+
+  → skip Day 3, complete puzzle on Day 4 (gap)
+  lastCompletionDate = "2026-06-30", currentStreak = 1, longestStreak = 2
+```

--- a/specs/004-daily-puzzle-streak/plan.md
+++ b/specs/004-daily-puzzle-streak/plan.md
@@ -1,0 +1,92 @@
+# Implementation Plan: Daily Puzzle Streak
+
+**Branch**: `004-daily-puzzle-streak` | **Date**: 2026-06-27 | **Spec**: [spec.md](spec.md)
+
+**Input**: Feature specification from `specs/004-daily-puzzle-streak/spec.md`
+
+## Summary
+
+Track and display a consecutive-day puzzle-completion streak. A streak increments by 1 when the player completes any puzzle on a calendar day immediately following the previous completion day; it resets to 1 after a gap; same-day completions are idempotent. Data persists via `shared_preferences` (already a project dependency) — no new packages required. The current streak and personal-best (longest) streak are surfaced on the win overlay immediately after puzzle completion.
+
+## Technical Context
+
+**Language/Version**: Dart 3.x (Flutter SDK 3.41.3, stable channel)
+
+**Primary Dependencies**: Flutter framework; `shared_preferences 2.5.5` (already in pubspec) — no new dependencies
+
+**Storage**: `SharedPreferences` only — three string/int keys under the `streak_` namespace, following the exact same pattern used by `CompletionService`. No SQLite, no Hive, no external database.
+
+**Testing**: `flutter_test` (built-in); `SharedPreferences.setMockInitialValues({})` in `setUp` — same pattern used by `completion_service_test.dart`
+
+**Target Platform**: Android (Flutter Android target, API 21+)
+
+**Project Type**: Mobile app (Flutter Android)
+
+**Performance Goals**: Streak read/write is a single `SharedPreferences` round-trip on the puzzle-completion event — no performance constraint beyond what `CompletionService` already satisfies
+
+**Constraints**: No network calls; offline-only; must not add any new package dependency
+
+**Scale/Scope**: Single user, single device; three `SharedPreferences` keys total
+
+## Constitution Check
+
+| Gate | Status | Notes |
+|------|--------|-------|
+| I. Children-First UI | ✅ | Win overlay addition must match existing childish palette; mockups in `assets/design/` to be consulted before implementation |
+| II. TDD — ≥85% line coverage | ✅ | `StreakRecord` and `StreakService` must have unit tests written first (red → green → refactor). `WinOverlay` changes need widget tests. |
+| III. Functional Programming | ✅ | `StreakRecord` is fully immutable with `copyWith`. State transformation in `StreakService` is a pure function mapping old record + date → new record. |
+| IV. DRY | ✅ | Single `StreakService` class owns all streak logic. No constants duplicated. SharedPreferences keys defined as private constants in one place. |
+| V. KISS & SOLID | ✅ | `StreakService` has one responsibility: streak state management. `StreakRecord` has one responsibility: value object. No premature abstraction. |
+| VI. Quality Gates | ✅ | `flutter test` + `flutter analyze` + `flutter build apk --debug` must pass before PR |
+
+**Complexity Tracking**: No violations requiring justification.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/004-daily-puzzle-streak/
+├── plan.md              ← this file
+├── research.md          ← Phase 0 decisions
+├── data-model.md        ← Phase 1 data model + service contract
+├── quickstart.md        ← Phase 1 validation guide
+├── checklists/
+│   └── requirements.md
+└── tasks.md             ← Phase 2 output (not yet created)
+```
+
+### Source Code
+
+```text
+lib/
+├── models/
+│   ├── streak_record.dart        ← NEW: immutable value object
+│   └── ...
+├── services/
+│   ├── streak_service.dart       ← NEW: SharedPreferences-backed streak logic
+│   ├── completion_service.dart   ← UNCHANGED
+│   └── ...
+├── widgets/
+│   ├── win_overlay.dart          ← MODIFIED: accept optional StreakRecord, show streak
+│   └── ...
+└── screens/
+    └── game_screen.dart          ← MODIFIED: call StreakService on win, pass record to overlay
+
+test/
+└── unit/
+    ├── models/
+    │   └── streak_record_test.dart     ← NEW
+    └── services/
+        └── streak_service_test.dart    ← NEW
+    unit/widgets/
+        └── win_overlay_test.dart       ← MODIFIED: add streak display tests
+
+lib/l10n/
+├── app_en.arb   ← MODIFIED: add streak string keys
+├── app_pl.arb   ← MODIFIED
+├── app_de.arb   ← MODIFIED
+└── app_es.arb   ← MODIFIED
+```
+
+**Structure Decision**: Flutter Android single-project layout. New files follow the existing `lib/models/` and `lib/services/` conventions exactly. Modified files are `win_overlay.dart`, `game_screen.dart`, and all four ARB localization files.

--- a/specs/004-daily-puzzle-streak/quickstart.md
+++ b/specs/004-daily-puzzle-streak/quickstart.md
@@ -1,0 +1,113 @@
+# Quickstart Validation Guide: Daily Puzzle Streak
+
+**Feature**: 004-daily-puzzle-streak | **Date**: 2026-06-27
+
+This guide describes how to validate the feature works end-to-end, both via automated tests and manual verification on a device/emulator.
+
+---
+
+## Prerequisites
+
+- Flutter 3.41.3 available (`/home/arogut/development/flutter/bin/flutter`)
+- `ANDROID_HOME=/home/arogut/Android/Sdk`
+- Feature branch `004-daily-puzzle-streak` checked out
+- All source files from [data-model.md](data-model.md) implemented
+
+---
+
+## Automated Test Validation
+
+### 1. Run the full test suite
+
+```bash
+/home/arogut/development/flutter/bin/flutter test
+```
+
+**Expected**: zero failures, ≥ 85% line coverage
+
+### 2. Key test files to verify exist and pass
+
+| Test file | What it covers |
+|-----------|----------------|
+| `test/unit/models/streak_record_test.dart` | `StreakRecord` immutability, `copyWith`, `initial()`, invariant asserts |
+| `test/unit/services/streak_service_test.dart` | All four streak transition paths (first ever, same-day, consecutive, gap); `getStreak()` on empty prefs; `resetAll()`; clock injection |
+| `test/unit/widgets/win_overlay_test.dart` | Overlay renders correctly without streakRecord; renders streak section when streakRecord provided; hides streak section when currentStreak == 0 |
+
+### 3. Static analysis
+
+```bash
+/home/arogut/development/flutter/bin/flutter analyze
+```
+
+**Expected**: zero issues, zero warnings
+
+### 4. Debug APK build
+
+```bash
+/home/arogut/development/flutter/bin/flutter build apk --debug
+```
+
+**Expected**: clean compilation, no errors
+
+---
+
+## Manual Validation Scenarios
+
+Connect to the Windows-hosted emulator (Pixel_Tablet_API_35) via ADB as described in the project memory before running these scenarios.
+
+### Scenario A — First puzzle completion starts streak at 1
+
+1. Fresh install (or clear app data in Android Settings)
+2. Complete any puzzle on any difficulty
+3. **Verify**: Win overlay shows "🔥 1 Day Streak" and "Best: 1 days"
+
+### Scenario B — Same-day completion does not inflate streak
+
+1. Complete a second puzzle on the same day (do not change device date)
+2. **Verify**: Win overlay still shows "🔥 1 Day Streak" (unchanged)
+
+### Scenario C — Consecutive day increments streak
+
+1. Advance the device date by exactly one day (Developer Options → System clock, or `adb shell date`)
+2. Complete any puzzle
+3. **Verify**: Win overlay shows "🔥 2 Day Streak"
+
+### Scenario D — Missed day resets streak to 1
+
+1. Advance the device date by two or more days
+2. Complete any puzzle
+3. **Verify**: Win overlay shows "🔥 1 Day Streak"; "Best:" retains the previous highest value
+
+### Scenario E — Longest streak is preserved after reset
+
+1. Build a streak of 3 across three consecutive days
+2. Skip one day and complete a puzzle (streak resets to 1)
+3. **Verify**: Win overlay shows "Best: 3 days"
+
+### Scenario F — Streak persists across app restarts
+
+1. Complete a puzzle (streak becomes N)
+2. Force-stop the app and reopen it
+3. Complete another puzzle on the same day
+4. **Verify**: Win overlay still shows streak = N (not reset)
+
+### Scenario G — Reset Progress clears streak
+
+1. Complete a puzzle to establish a streak
+2. Navigate to Settings → Reset Progress → confirm
+3. Complete a new puzzle
+4. **Verify**: Win overlay shows "🔥 1 Day Streak" (streak restarted from zero)
+
+---
+
+## Acceptance Criteria Cross-reference
+
+| Scenario | Spec acceptance scenario covered |
+|----------|----------------------------------|
+| A | US1-AC2, US3-AC1 |
+| B | US1-AC3, US1-AC4 |
+| C | US1-AC1 |
+| D | US2-AC1 |
+| E | US4-AC2 |
+| F | SC-002 |
+| G | SC-004 |

--- a/specs/004-daily-puzzle-streak/research.md
+++ b/specs/004-daily-puzzle-streak/research.md
@@ -1,0 +1,73 @@
+# Research: Daily Puzzle Streak
+
+**Phase**: 0 | **Date**: 2026-06-27 | **Feature**: [spec.md](spec.md)
+
+No external research required — all decisions resolved from existing project context.
+
+---
+
+## Decision 1: Storage Mechanism
+
+**Decision**: Use `shared_preferences` (already in `pubspec.yaml`) to persist streak state as three primitive keys.
+
+**Rationale**: The user explicitly requested no internal databases and to reuse existing dependencies. `SharedPreferences` is already used by `CompletionService` for the same kind of lightweight persistent state (a handful of typed key-value pairs). Adding a new package (e.g., Hive, SQLite) would violate both the user constraint and the constitution's YAGNI principle.
+
+**Alternatives considered**:
+- `sqflite` / `drift` — overkill for three values; adds a dependency; explicitly ruled out by the user
+- In-memory only — streak would be lost on app restart; violates FR-005
+- File I/O — more complexity than `SharedPreferences`; no benefit
+
+**SharedPreferences keys chosen**:
+| Key | Type | Meaning |
+|-----|------|---------|
+| `streak_current` | `int` | Current consecutive-day streak count (≥ 0) |
+| `streak_longest` | `int` | All-time longest streak (≥ 0) |
+| `streak_last_date` | `String?` | ISO date of last completion (`YYYY-MM-DD`), null if never |
+
+---
+
+## Decision 2: Date Representation
+
+**Decision**: Store the date as a plain `YYYY-MM-DD` string (ISO 8601 date-only format). Compare strings directly; use `DateTime.now()` to extract the local date.
+
+**Rationale**: No time zone conversion complexity. The spec says a "day" is the device's local calendar day. `DateTime.now()` gives local time; formatting it as `YYYY-MM-DD` captures the calendar day in the device time zone.
+
+**Alternatives considered**:
+- UTC epoch timestamp — would require timezone-aware day comparison; unnecessary complexity
+- Full `DateTime.toIso8601String()` — includes time component, making same-day comparison harder
+
+---
+
+## Decision 3: Testability Without External Packages
+
+**Decision**: `StreakService` accepts an optional `DateTime Function()` parameter named `clock`, defaulting to `() => DateTime.now()`. Tests inject a fake clock by passing a closure that returns a fixed date.
+
+**Rationale**: Streak logic is date-sensitive — tests must control the "current date" to verify increment, same-day, and reset scenarios deterministically. Injecting a clock closure costs nothing (no extra package, no interface) and follows the existing project style of keeping things simple. No `clock` package or `mocktail` mock of `DateTime` is needed.
+
+**Alternatives considered**:
+- `mocktail` / `mockito` mock of a `Clock` interface — more boilerplate than a simple closure
+- `clock` pub package — an unnecessary new dependency
+
+---
+
+## Decision 4: Integration Point
+
+**Decision**: Call `StreakService.recordPuzzleCompletion()` inside `GameScreen._recordCompletion()`, immediately after the existing `CompletionService.recordCompletion()` call. Store the returned `StreakRecord` in `_GameScreenState` and pass it to `WinOverlay`.
+
+**Rationale**: `_recordCompletion()` is already the single place where puzzle completion is actioned. Keeping the streak call adjacent to the existing completion call avoids scattering the win logic. `WinOverlay` receives the record as a constructor parameter (nullable) — backward-compatible and testable.
+
+**Alternatives considered**:
+- Calling `StreakService` inside `GameState.endDrag()` — violates SRP (state management shouldn't know about persistence)
+- Loading streak separately in `WinOverlay` itself — mixes data-fetching into a UI widget; violates constitution principle V
+
+---
+
+## Decision 5: Win Overlay Display
+
+**Decision**: Add a `StreakRecord? streakRecord` parameter to `WinOverlay`. When non-null and `currentStreak > 0`, display the current streak (e.g. "🔥 5 Day Streak") and longest streak ("Best: 12 days") using existing text styles and the childish palette. Localization strings go through the existing ARB pipeline.
+
+**Rationale**: The `WinOverlay` already uses localized strings. Extending its constructor is the surgical, minimal change — no new widget file needed. The nullable parameter means existing tests that construct `WinOverlay` without a streak record continue to work.
+
+**Alternatives considered**:
+- New `StreakBadge` widget composed into `WinOverlay` — adds a file and an abstraction layer for what is a small UI addition; YAGNI
+- Separate streak screen/page — not requested; over-scope

--- a/specs/004-daily-puzzle-streak/spec.md
+++ b/specs/004-daily-puzzle-streak/spec.md
@@ -1,0 +1,124 @@
+# Feature Specification: Daily Puzzle Streak
+
+**Feature Branch**: `004-daily-puzzle-streak`
+
+**Created**: 2026-06-27
+
+**Status**: Draft
+
+**Input**: User description: "New feature that will be counting streak of how many days in a row user was resolving puzzles. This should not be about just starting the app, but solving at least one jigsaw puzzle."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Streak Increments on Puzzle Completion (Priority: P1)
+
+A user who completes a puzzle on a new calendar day sees their streak counter go up by one. The streak only grows through finishing a puzzle — merely opening the app has no effect.
+
+**Why this priority**: This is the core mechanic. Without it the feature does not exist. All other stories build on correct streak counting.
+
+**Independent Test**: Can be fully tested by completing a puzzle after simulating consecutive days and verifying the counter increments correctly; delivers the fundamental "daily habit" value to the user.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user has a streak of 3 and completed their last puzzle yesterday, **When** they finish any puzzle today, **Then** the streak becomes 4.
+2. **Given** the user has never completed a puzzle, **When** they finish their first puzzle, **Then** a new streak of 1 begins.
+3. **Given** the user already completed a puzzle today (streak = 5), **When** they finish another puzzle today, **Then** the streak remains 5 (same-day completion does not double-count).
+4. **Given** the user is on a streak of 2, **When** they finish a puzzle on the same day as their last completion, **Then** the last-completion date is updated but the streak count is unchanged.
+
+---
+
+### User Story 2 - Streak Resets After a Missed Day (Priority: P2)
+
+A user who skips a day without completing any puzzle has their streak reset to 1 the next time they finish a puzzle.
+
+**Why this priority**: Without correct reset behaviour the streak counter is meaningless. This story defines the "consequence" half of the habit loop and is essential to the feature's integrity.
+
+**Independent Test**: Can be fully tested by simulating a two-day gap between puzzle completions and verifying the streak resets to 1.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user has a streak of 7 and last completed a puzzle two days ago, **When** they finish a puzzle today, **Then** the streak resets to 1.
+2. **Given** the user has a streak of 1 and last completed a puzzle three days ago, **When** they finish a puzzle today, **Then** the streak becomes 1 (no change, already at minimum).
+3. **Given** the user has never completed a puzzle, **When** they open the app without finishing a puzzle, **Then** no streak is shown (or streak remains 0).
+
+---
+
+### User Story 3 - Streak Display on Win Screen (Priority: P3)
+
+After completing a puzzle, the user can see their updated current streak displayed on the win overlay so they get immediate positive feedback.
+
+**Why this priority**: Immediate feedback on the win screen closes the habit loop and is the primary motivational touchpoint. It is independently deployable once streak tracking is in place.
+
+**Independent Test**: Can be tested by completing a puzzle and verifying the win overlay shows the correct streak value matching the stored record.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user finishes a puzzle and the streak is now 5, **When** the win overlay appears, **Then** it shows "5 day streak" (or equivalent child-friendly label).
+2. **Given** the user finishes a puzzle and the streak has just reset to 1, **When** the win overlay appears, **Then** it shows "1 day streak".
+3. **Given** the user finishes a puzzle and today already counted toward the streak, **When** the win overlay appears, **Then** the unchanged streak count is shown correctly.
+
+---
+
+### User Story 4 - Longest Streak Record (Priority: P4)
+
+The system tracks the user's all-time longest streak and displays it alongside the current streak, so the user has a personal best to chase.
+
+**Why this priority**: Adds motivational depth without changing any core mechanic. It is a simple extension once current streak tracking is correct.
+
+**Independent Test**: Can be tested by simulating a long streak followed by a reset and verifying the longest-streak record is preserved.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user's current streak is 10 and longest ever was 8, **When** the win overlay is shown, **Then** the longest streak is updated to 10 and displayed.
+2. **Given** the user's streak resets to 1, **When** the win overlay is shown, **Then** the longest streak value is unchanged (still the previous best).
+3. **Given** the user has never had a streak longer than their current one, **When** they keep extending their current streak, **Then** the longest streak always mirrors the current streak.
+
+---
+
+### Edge Cases
+
+- What happens when the user changes the device date/time manually? The feature relies on the device calendar day; no additional validation is performed (out of scope).
+- What happens if persistent storage is cleared (app data reset)? Streak resets to 0 — no recovery mechanism.
+- What happens when a puzzle is completed at exactly midnight? The completion date is determined by the calendar day at the moment the puzzle is won; whichever day the device clock reports at that moment is used.
+- What happens if the same puzzle is completed multiple times in one session? Each completion event is checked; only the first completion of a new calendar day advances the streak.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST record the calendar date each time a puzzle is completed (the "won" state is reached).
+- **FR-002**: The system MUST increment the current streak by 1 when a puzzle is completed on a calendar day immediately following the day of the previous completion.
+- **FR-003**: The system MUST keep the current streak unchanged when a puzzle is completed on the same calendar day as the most recent completion.
+- **FR-004**: The system MUST reset the current streak to 1 when a puzzle is completed after one or more calendar days have been skipped since the last completion.
+- **FR-005**: The system MUST persist the current streak, the longest streak, and the last-completion date across app sessions (i.e., data survives the app being closed and reopened).
+- **FR-006**: The system MUST update the longest streak whenever the current streak exceeds the previously stored longest streak.
+- **FR-007**: The system MUST display the current streak count to the user on the win overlay immediately after a puzzle is completed.
+- **FR-008**: The system MUST display the longest streak to the user on the win overlay.
+- **FR-009**: Streak tracking MUST be global across all puzzle images and all difficulty levels — any completed puzzle counts.
+
+### Key Entities
+
+- **StreakRecord**: Represents the user's streak state. Holds the current streak count (integer ≥ 0), the longest streak ever achieved (integer ≥ 0), and the date of the most recent puzzle completion (nullable date). Immutable; updated via pure transformation.
+- **StreakService** (boundary): Encapsulates the rules for reading and updating a StreakRecord given the current date and a completion event. Depends on an abstract persistence interface.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: After any puzzle completion, the displayed streak count is always accurate — it matches the number of consecutive calendar days (ending today) on which at least one puzzle was completed.
+- **SC-002**: Streak data is fully preserved when the app is closed and reopened; the streak shown after reopening is identical to the one shown at the end of the previous session.
+- **SC-003**: Completing multiple puzzles on the same day never inflates the streak beyond 1 increment for that day; this invariant holds in 100% of cases.
+- **SC-004**: After a missed day, the first puzzle completion resets the streak to exactly 1; no partially-preserved streak values are shown.
+- **SC-005**: The longest streak record is always ≥ the current streak and is never decremented by a streak reset.
+- **SC-006**: The streak information is visible to the user within the natural game completion flow, without requiring any additional navigation.
+
+## Assumptions
+
+- **Streak scope**: All puzzle images and difficulty levels count equally toward the streak — there is no per-difficulty or per-image streak.
+- **Calendar day definition**: A "day" is defined by the local device calendar date (midnight-to-midnight in the device time zone). No server-side clock is used.
+- **No notifications**: Out-of-scope for this feature — no push notifications or reminders to maintain the streak.
+- **No cloud sync**: Streak data is stored locally on the device only. Cross-device sync is out of scope.
+- **Single user**: The app has no user account system; all streak data belongs to whichever person uses the device.
+- **Data loss on clear**: If the user clears app data or reinstalls, the streak is lost. No backup or recovery mechanism is provided.
+- **Display location**: Streak is shown on the win overlay (post-puzzle completion screen). Whether it also appears elsewhere (e.g., image selection screen) is deferred to planning.
+- **Child-friendly presentation**: The streak display must follow the constitution's children-first UI design principle — large text, bright colours, celebratory feel — consistent with existing win overlay design.

--- a/specs/004-daily-puzzle-streak/tasks.md
+++ b/specs/004-daily-puzzle-streak/tasks.md
@@ -1,0 +1,178 @@
+# Tasks: Daily Puzzle Streak
+
+**Input**: Design documents from `specs/004-daily-puzzle-streak/`
+
+**Prerequisites**: [plan.md](plan.md) · [spec.md](spec.md) · [data-model.md](data-model.md) · [research.md](research.md) · [quickstart.md](quickstart.md)
+
+**TDD mandate**: Constitution Principle II requires tests to be written and confirmed FAILING before implementation. Every implementation task is preceded by its corresponding test task.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: Which user story this belongs to ([US1]–[US4])
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Branch setup — no new packages, no schema migrations required.
+
+- [x] T001 Create git branch `004-daily-puzzle-streak` from `main` and confirm working tree is clean
+
+---
+
+## Phase 2: Foundational — StreakRecord + StreakService (TDD)
+
+**Purpose**: Core data model and service that ALL user stories depend on. Must be 100% complete before any UI or integration work begins.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+> **TDD**: Write T002 and T003 first, confirm they FAIL, then implement T004 and T005.
+
+- [x] T002 [P] Write failing unit tests for `StreakRecord` in `test/unit/models/streak_record_test.dart`: cover `initial()` factory (zeros + null date), `copyWith` preserving unchanged fields, and `assert` violations (negative counts, longestStreak < currentStreak)
+- [x] T003 [P] Write failing unit tests for `StreakService` in `test/unit/services/streak_service_test.dart`: cover all four transition paths (first-ever completion → streak 1; same-day → idempotent; consecutive day → increments; gap of 2+ days → resets to 1); `getStreak()` on empty prefs returns `StreakRecord.initial()`; `resetAll()` removes all three keys; clock injection controls the "current date"
+- [x] T004 Implement `StreakRecord` immutable value object with `initial()` factory and `copyWith` in `lib/models/streak_record.dart` (makes T002 green; doc-comment every public member)
+- [x] T005 Implement `StreakService` with `getStreak()`, `recordPuzzleCompletion()`, and `resetAll()` using `shared_preferences` and optional `clock` injection in `lib/services/streak_service.dart` (makes T003 green; doc-comment every public member)
+
+**Checkpoint**: `flutter test test/unit/models/streak_record_test.dart test/unit/services/streak_service_test.dart` passes with zero failures.
+
+---
+
+## Phase 3: User Stories 1 & 2 — Streak Counting in GameScreen (Priority: P1 + P2) 🎯 MVP
+
+**Goal**: When any puzzle is won, the app records the completion via `StreakService` and stores the resulting `StreakRecord` in `_GameScreenState`, ready to pass to the win overlay. US1 (increment) and US2 (reset) are both exercised through this single integration point.
+
+**Independent Test**: After triggering a puzzle win in a widget test (with `SharedPreferences` mocked to empty initial values), the `WinOverlay` in the widget tree is found to receive a `streakRecord` with `currentStreak == 1`.
+
+> **TDD**: Write T006 first, confirm it FAILS, then implement T007–T009.
+
+- [x] T006 [US1] Write failing widget test in `test/widget/game_screen_loaded_test.dart`: set up `SharedPreferences.setMockInitialValues({})`, trigger `GamePhase.won`, and assert the rendered `WinOverlay` receives a `streakRecord` argument with `currentStreak >= 1`
+- [x] T007 [US1] Add `StreakRecord? _streakRecord` field to `_GameScreenState` in `lib/screens/game_screen.dart`
+- [x] T008 [US1] Extend `_recordCompletion()` in `lib/screens/game_screen.dart` to call `await StreakService().recordPuzzleCompletion()` and store the result in `_streakRecord` via `setState()`
+- [x] T009 [US1] Pass `streakRecord: _streakRecord` to the `WinOverlay(...)` constructor call in `lib/screens/game_screen.dart` (makes T006 green)
+
+**Checkpoint**: `flutter test test/widget/game_screen_loaded_test.dart` passes; `flutter analyze` clean.
+
+---
+
+## Phase 4: User Stories 3 & 4 — Win Overlay Streak Display (Priority: P3 + P4)
+
+**Goal**: The win overlay shows the updated current streak (US3) and the all-time longest streak (US4) immediately after puzzle completion. Both are read from `StreakRecord` already stored in `_GameScreenState`.
+
+**Independent Test**: Construct `WinOverlay` with a `StreakRecord(currentStreak: 5, longestStreak: 12, lastCompletionDate: '2026-06-27')` in a widget test and assert "5 Day Streak" and "Best: 12" appear in the rendered tree.
+
+> **TDD**: Write T011 first, confirm it FAILS, then implement T012–T013.
+
+- [ ] T010 [P] [US3] Add localization keys `streakDays` (with `count` int placeholder) and `streakBest` (with `count` int placeholder) to all four ARB files: `lib/l10n/app_en.arb`, `lib/l10n/app_pl.arb`, `lib/l10n/app_de.arb`, `lib/l10n/app_es.arb` (EN: `"🔥 {count} Day Streak"` / `"Best: {count} days"`)
+- [ ] T011 [US3] Write failing widget tests in `test/unit/widgets/win_overlay_test.dart`: (a) null `streakRecord` renders correctly with no streak section; (b) `streakRecord` with `currentStreak > 0` shows streak text and longest streak; (c) `streakRecord` with `currentStreak == 0` hides streak section
+- [ ] T012 [US3] Add `final StreakRecord? streakRecord` named parameter (default `null`) to `WinOverlay` constructor in `lib/widgets/win_overlay.dart` (doc-comment the new field)
+- [ ] T013 [US3] Add streak display section to `WinOverlay.build()` in `lib/widgets/win_overlay.dart`: render between subtitle and buttons when `streakRecord != null && streakRecord!.currentStreak > 0`; use `l10n.streakDays(count: streakRecord!.currentStreak)` and `l10n.streakBest(count: streakRecord!.longestStreak)`; match existing childish palette (makes T011 green)
+
+**Checkpoint**: `flutter test test/unit/widgets/win_overlay_test.dart` passes; `WinOverlay` renders correctly for null and non-null `streakRecord` cases.
+
+---
+
+## Phase 5: Settings Integration & Polish
+
+**Purpose**: Wire `StreakService.resetAll()` into the existing "Reset Progress" flow so a settings reset also clears the streak. Then run all quality gates.
+
+- [ ] T014 Write failing widget test in `test/widget/settings_screen_test.dart` asserting that after tapping "Reset Progress", subsequent `StreakService().getStreak()` returns `StreakRecord.initial()` (use `SharedPreferences.setMockInitialValues({'streak_current': 5, 'streak_longest': 10, 'streak_last_date': '2026-06-01'})`)
+- [ ] T015 Extend the "Reset Progress" action in `lib/screens/settings_screen.dart` to call `await StreakService().resetAll()` alongside the existing `CompletionService().resetAll()` call (makes T014 green)
+- [ ] T016 [P] Run all quality gates in order: `flutter test`, `flutter analyze`, `flutter build apk --debug`; resolve any failures before raising a PR
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies — start immediately
+- **Phase 2 (Foundational)**: Depends on Phase 1 — **blocks all user story work**
+- **Phase 3 (US1/US2)**: Depends on Phase 2 (needs `StreakRecord` + `StreakService`)
+- **Phase 4 (US3/US4)**: Depends on Phase 2 (needs `StreakRecord`); depends on T010 (localization) before T011 can compile
+- **Phase 5 (Polish)**: Depends on Phases 3 and 4
+
+### User Story Dependencies
+
+| Story | Phase | Depends on | Can start after |
+|-------|-------|------------|-----------------|
+| US1 + US2 | Phase 3 | Phase 2 complete | T005 merged |
+| US3 + US4 | Phase 4 | T004 (StreakRecord) + T010 (l10n) | T004 + T010 done |
+| Settings (T014-T015) | Phase 5 | Phase 2 + Phase 3 | T009 merged |
+
+### Within Phase 2
+
+- T002 and T003 are parallel (different test files, no shared code)
+- T004 must precede T005 (`StreakService` imports `StreakRecord`)
+
+### Within Phase 4
+
+- T010 must precede T011 (localization keys must exist for test to compile)
+- T012 must precede T013 (`WinOverlay` constructor change before body change)
+- T011 can be written against the stub constructor from T012 before T013 fills the implementation
+
+---
+
+## Parallel Opportunities
+
+### Phase 2 (run together)
+
+```
+T002  Write StreakRecord tests    (test/unit/models/streak_record_test.dart)
+T003  Write StreakService tests   (test/unit/services/streak_service_test.dart)
+```
+
+### Phases 3 and 4 (after Phase 2)
+
+Phases 3 and 4 can be worked in parallel by different developers once `StreakRecord` (T004) is done.
+
+```
+Developer A → Phase 3: T006 → T007 → T008 → T009  (GameScreen integration)
+Developer B → Phase 4: T010 → T011 → T012 → T013  (WinOverlay display)
+```
+
+---
+
+## Parallel Example: Phase 2
+
+```
+# These two test-writing tasks run in parallel:
+Task T002: "Write failing StreakRecord tests in test/unit/models/streak_record_test.dart"
+Task T003: "Write failing StreakService tests in test/unit/services/streak_service_test.dart"
+
+# After both fail as expected, implement in order:
+Task T004: "Implement StreakRecord in lib/models/streak_record.dart"   ← makes T002 green
+Task T005: "Implement StreakService in lib/services/streak_service.dart"  ← makes T003 green
+```
+
+---
+
+## Implementation Strategy
+
+### MVP (Phase 1 + Phase 2 + Phase 3 only)
+
+1. Phase 1: Create branch
+2. Phase 2: Implement `StreakRecord` + `StreakService` with full TDD
+3. Phase 3: Wire into `GameScreen`
+4. **STOP and VALIDATE**: The streak is tracked and `_streakRecord` is populated on win — verifiable via `flutter test` and debug output
+5. The win overlay will not show the streak yet (Phase 4 not done) — this is the deliberate MVP boundary
+
+### Incremental Delivery
+
+1. After Phase 2: Streak logic is complete and unit-tested
+2. After Phase 3: Streak is tracked in the live app on puzzle completion (no UI yet)
+3. After Phase 4: Full feature — streak displayed to player after every win
+4. After Phase 5: Reset flow complete; all quality gates pass; ready for PR
+
+---
+
+## Notes
+
+- `[P]` tasks touch different files and have no mutual dependencies — safe to run concurrently
+- `[Story]` labels map each task to a user story for spec traceability
+- All new public Dart symbols (classes, constructors, methods, fields) MUST have `///` doc comments — this is a hard constitution requirement
+- `SharedPreferences.setMockInitialValues({})` must appear in `setUp()` for every test file that touches `StreakService`
+- The `clock` parameter on `StreakService` is the only mechanism for date control in tests — do not use `mockito`/`mocktail` for `DateTime`
+- Run `flutter test --coverage` locally before raising a PR to confirm ≥ 85% line coverage

--- a/specs/004-daily-puzzle-streak/tasks.md
+++ b/specs/004-daily-puzzle-streak/tasks.md
@@ -65,10 +65,10 @@
 
 > **TDD**: Write T011 first, confirm it FAILS, then implement T012–T013.
 
-- [ ] T010 [P] [US3] Add localization keys `streakDays` (with `count` int placeholder) and `streakBest` (with `count` int placeholder) to all four ARB files: `lib/l10n/app_en.arb`, `lib/l10n/app_pl.arb`, `lib/l10n/app_de.arb`, `lib/l10n/app_es.arb` (EN: `"🔥 {count} Day Streak"` / `"Best: {count} days"`)
-- [ ] T011 [US3] Write failing widget tests in `test/unit/widgets/win_overlay_test.dart`: (a) null `streakRecord` renders correctly with no streak section; (b) `streakRecord` with `currentStreak > 0` shows streak text and longest streak; (c) `streakRecord` with `currentStreak == 0` hides streak section
-- [ ] T012 [US3] Add `final StreakRecord? streakRecord` named parameter (default `null`) to `WinOverlay` constructor in `lib/widgets/win_overlay.dart` (doc-comment the new field)
-- [ ] T013 [US3] Add streak display section to `WinOverlay.build()` in `lib/widgets/win_overlay.dart`: render between subtitle and buttons when `streakRecord != null && streakRecord!.currentStreak > 0`; use `l10n.streakDays(count: streakRecord!.currentStreak)` and `l10n.streakBest(count: streakRecord!.longestStreak)`; match existing childish palette (makes T011 green)
+- [x] T010 [P] [US3] Add localization keys `streakDays` (with `count` int placeholder) and `streakBest` (with `count` int placeholder) to all four ARB files: `lib/l10n/app_en.arb`, `lib/l10n/app_pl.arb`, `lib/l10n/app_de.arb`, `lib/l10n/app_es.arb` (EN: `"🔥 {count} Day Streak"` / `"Best: {count} days"`)
+- [x] T011 [US3] Write failing widget tests in `test/unit/widgets/win_overlay_test.dart`: (a) null `streakRecord` renders correctly with no streak section; (b) `streakRecord` with `currentStreak > 0` shows streak text and longest streak; (c) `streakRecord` with `currentStreak == 0` hides streak section
+- [x] T012 [US3] Add `final StreakRecord? streakRecord` named parameter (default `null`) to `WinOverlay` constructor in `lib/widgets/win_overlay.dart` (doc-comment the new field)
+- [x] T013 [US3] Add streak display section to `WinOverlay.build()` in `lib/widgets/win_overlay.dart`: render between subtitle and buttons when `streakRecord != null && streakRecord!.currentStreak > 0`; use `l10n.streakDays(count: streakRecord!.currentStreak)` and `l10n.streakBest(count: streakRecord!.longestStreak)`; match existing childish palette (makes T011 green)
 
 **Checkpoint**: `flutter test test/unit/widgets/win_overlay_test.dart` passes; `WinOverlay` renders correctly for null and non-null `streakRecord` cases.
 
@@ -78,9 +78,9 @@
 
 **Purpose**: Wire `StreakService.resetAll()` into the existing "Reset Progress" flow so a settings reset also clears the streak. Then run all quality gates.
 
-- [ ] T014 Write failing widget test in `test/widget/settings_screen_test.dart` asserting that after tapping "Reset Progress", subsequent `StreakService().getStreak()` returns `StreakRecord.initial()` (use `SharedPreferences.setMockInitialValues({'streak_current': 5, 'streak_longest': 10, 'streak_last_date': '2026-06-01'})`)
-- [ ] T015 Extend the "Reset Progress" action in `lib/screens/settings_screen.dart` to call `await StreakService().resetAll()` alongside the existing `CompletionService().resetAll()` call (makes T014 green)
-- [ ] T016 [P] Run all quality gates in order: `flutter test`, `flutter analyze`, `flutter build apk --debug`; resolve any failures before raising a PR
+- [x] T014 Write failing widget test in `test/widget/settings_screen_test.dart` asserting that after tapping "Reset Progress", subsequent `StreakService().getStreak()` returns `StreakRecord.initial()` (use `SharedPreferences.setMockInitialValues({'streak_current': 5, 'streak_longest': 10, 'streak_last_date': '2026-06-01'})`)
+- [x] T015 Extend the "Reset Progress" action in `lib/screens/settings_screen.dart` to call `await StreakService().resetAll()` alongside the existing `CompletionService().resetAll()` call (makes T014 green)
+- [x] T016 [P] Run all quality gates in order: `flutter test`, `flutter analyze`, `flutter build apk --debug`; resolve any failures before raising a PR
 
 ---
 

--- a/test/unit/models/streak_record_test.dart
+++ b/test/unit/models/streak_record_test.dart
@@ -1,0 +1,105 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lily_jigsaw_puzzle/models/streak_record.dart';
+
+void main() {
+  group('StreakRecord', () {
+    test('initial() returns zero counts and null date', () {
+      final record = StreakRecord.initial();
+      expect(record.currentStreak, 0);
+      expect(record.longestStreak, 0);
+      expect(record.lastCompletionDate, isNull);
+    });
+
+    test('initial() equals a manually constructed zero record', () {
+      expect(
+        StreakRecord.initial(),
+        const StreakRecord(currentStreak: 0, longestStreak: 0),
+      );
+    });
+
+    test('copyWith overrides currentStreak and preserves other fields', () {
+      const original = StreakRecord(
+        currentStreak: 3,
+        longestStreak: 7,
+        lastCompletionDate: '2026-06-27',
+      );
+      final copy = original.copyWith(currentStreak: 4, longestStreak: 7);
+      expect(copy.currentStreak, 4);
+      expect(copy.longestStreak, 7);
+      expect(copy.lastCompletionDate, '2026-06-27');
+    });
+
+    test('copyWith with all fields replaces all values', () {
+      const original = StreakRecord(
+        currentStreak: 1,
+        longestStreak: 5,
+        lastCompletionDate: '2026-01-01',
+      );
+      final copy = original.copyWith(
+        currentStreak: 2,
+        longestStreak: 6,
+        lastCompletionDate: '2026-01-02',
+      );
+      expect(copy.currentStreak, 2);
+      expect(copy.longestStreak, 6);
+      expect(copy.lastCompletionDate, '2026-01-02');
+    });
+
+    test('copyWith with no arguments returns equal record', () {
+      const original = StreakRecord(
+        currentStreak: 3,
+        longestStreak: 5,
+        lastCompletionDate: '2026-06-01',
+      );
+      final copy = original.copyWith();
+      expect(copy, original);
+    });
+
+    test('given_negative_currentStreak_when_constructed_then_assert_fires', () {
+      expect(
+        () => StreakRecord(currentStreak: -1, longestStreak: 0),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
+    test('given_negative_longestStreak_when_constructed_then_assert_fires', () {
+      expect(
+        () => StreakRecord(currentStreak: 0, longestStreak: -1),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
+    test('given_longestStreak_less_than_currentStreak_when_constructed_then_assert_fires', () {
+      expect(
+        () => StreakRecord(currentStreak: 5, longestStreak: 3),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
+    test('equality holds for records with identical values', () {
+      const a = StreakRecord(
+        currentStreak: 2,
+        longestStreak: 5,
+        lastCompletionDate: '2026-06-27',
+      );
+      const b = StreakRecord(
+        currentStreak: 2,
+        longestStreak: 5,
+        lastCompletionDate: '2026-06-27',
+      );
+      expect(a, equals(b));
+    });
+
+    test('inequality when fields differ', () {
+      const a = StreakRecord(currentStreak: 1, longestStreak: 1);
+      const b = StreakRecord(currentStreak: 2, longestStreak: 2);
+      expect(a, isNot(equals(b)));
+    });
+
+    test('hashCode is consistent for equal records', () {
+      const a = StreakRecord(currentStreak: 3, longestStreak: 7, lastCompletionDate: '2026-06-01');
+      const b = StreakRecord(currentStreak: 3, longestStreak: 7, lastCompletionDate: '2026-06-01');
+      expect(a.hashCode, b.hashCode);
+    });
+  });
+}

--- a/test/unit/services/streak_service_test.dart
+++ b/test/unit/services/streak_service_test.dart
@@ -1,0 +1,119 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lily_jigsaw_puzzle/models/streak_record.dart';
+import 'package:lily_jigsaw_puzzle/services/streak_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+DateTime _date(String iso) => DateTime.parse(iso);
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  group('StreakService.getStreak()', () {
+    test('given_empty_prefs_when_getStreak_called_then_returns_initial', () async {
+      final record = await StreakService().getStreak();
+      expect(record, StreakRecord.initial());
+    });
+  });
+
+  group('StreakService.recordPuzzleCompletion() — first ever', () {
+    test('given_no_prior_completion_when_first_puzzle_completed_then_streak_is_1', () async {
+      final svc = StreakService(clock: () => _date('2026-06-27'));
+      final record = await svc.recordPuzzleCompletion();
+      expect(record.currentStreak, 1);
+      expect(record.longestStreak, 1);
+      expect(record.lastCompletionDate, '2026-06-27');
+    });
+  });
+
+  group('StreakService.recordPuzzleCompletion() — same day (idempotent)', () {
+    test('given_streak_1_when_second_puzzle_same_day_then_streak_unchanged', () async {
+      final svc = StreakService(clock: () => _date('2026-06-27'));
+      await svc.recordPuzzleCompletion();
+      final record = await svc.recordPuzzleCompletion();
+      expect(record.currentStreak, 1);
+      expect(record.longestStreak, 1);
+      expect(record.lastCompletionDate, '2026-06-27');
+    });
+  });
+
+  group('StreakService.recordPuzzleCompletion() — consecutive days', () {
+    test('given_streak_1_when_completed_on_next_day_then_streak_becomes_2', () async {
+      await StreakService(clock: () => _date('2026-06-27')).recordPuzzleCompletion();
+      final record =
+          await StreakService(clock: () => _date('2026-06-28')).recordPuzzleCompletion();
+      expect(record.currentStreak, 2);
+      expect(record.longestStreak, 2);
+      expect(record.lastCompletionDate, '2026-06-28');
+    });
+
+    test('given_streak_5_when_completed_on_next_day_then_longest_updates', () async {
+      for (var i = 0; i < 5; i++) {
+        await StreakService(clock: () => DateTime(2026, 6, 1 + i)).recordPuzzleCompletion();
+      }
+      final record =
+          await StreakService(clock: () => _date('2026-06-06')).recordPuzzleCompletion();
+      expect(record.currentStreak, 6);
+      expect(record.longestStreak, 6);
+    });
+  });
+
+  group('StreakService.recordPuzzleCompletion() — missed days (reset)', () {
+    test('given_streak_7_when_gap_of_2_days_then_streak_resets_to_1', () async {
+      for (var i = 0; i < 7; i++) {
+        await StreakService(clock: () => DateTime(2026, 6, 20 + i)).recordPuzzleCompletion();
+      }
+      // Last was June 26; skipping June 27; completing on June 28 (2-day gap)
+      final record =
+          await StreakService(clock: () => _date('2026-06-28')).recordPuzzleCompletion();
+      expect(record.currentStreak, 1);
+      expect(record.longestStreak, 7);
+      expect(record.lastCompletionDate, '2026-06-28');
+    });
+
+    test('given_streak_3_when_gap_of_10_days_then_streak_resets_to_1', () async {
+      for (var i = 0; i < 3; i++) {
+        await StreakService(clock: () => DateTime(2026, 6, 1 + i)).recordPuzzleCompletion();
+      }
+      final record =
+          await StreakService(clock: () => _date('2026-06-20')).recordPuzzleCompletion();
+      expect(record.currentStreak, 1);
+      expect(record.longestStreak, 3);
+    });
+
+    test('longest_streak_is_preserved_after_reset', () async {
+      for (var i = 0; i < 3; i++) {
+        await StreakService(clock: () => DateTime(2026, 6, 1 + i)).recordPuzzleCompletion();
+      }
+      final record =
+          await StreakService(clock: () => _date('2026-06-10')).recordPuzzleCompletion();
+      expect(record.currentStreak, 1);
+      expect(record.longestStreak, 3);
+    });
+  });
+
+  group('StreakService — clock injection', () {
+    test('given_custom_clock_when_completing_then_date_matches_injected_date', () async {
+      final svc = StreakService(clock: () => DateTime(2000, 1, 15));
+      final record = await svc.recordPuzzleCompletion();
+      expect(record.lastCompletionDate, '2000-01-15');
+    });
+
+    test('single_digit_month_and_day_are_zero_padded', () async {
+      final svc = StreakService(clock: () => DateTime(2026, 3, 5));
+      final record = await svc.recordPuzzleCompletion();
+      expect(record.lastCompletionDate, '2026-03-05');
+    });
+  });
+
+  group('StreakService.resetAll()', () {
+    test('given_existing_streak_when_resetAll_then_getStreak_returns_initial', () async {
+      final svc = StreakService(clock: () => _date('2026-06-27'));
+      await svc.recordPuzzleCompletion();
+      await svc.resetAll();
+      final record = await svc.getStreak();
+      expect(record, StreakRecord.initial());
+    });
+  });
+}

--- a/test/unit/widgets/win_overlay_test.dart
+++ b/test/unit/widgets/win_overlay_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lily_jigsaw_puzzle/l10n/app_localizations.dart';
+import 'package:lily_jigsaw_puzzle/models/streak_record.dart';
 import 'package:lily_jigsaw_puzzle/widgets/win_overlay.dart';
 
 Widget _wrap(Widget child) {
@@ -67,6 +68,87 @@ void main() {
       await tester.pump();
 
       expect(find.text('🎉'), findsOneWidget);
+    });
+
+    testWidgets('given_null_streakRecord_when_rendered_then_no_streak_section', (tester) async {
+      await tester.pumpWidget(
+        _wrap(WinOverlay(onPlayAgain: () {}, onNewPuzzle: () {})),
+      );
+      await tester.pump();
+
+      expect(find.textContaining('Day Streak'), findsNothing,
+          reason: 'streak section must not appear when streakRecord is null');
+    });
+
+    testWidgets('given_streakRecord_with_zero_streak_when_rendered_then_no_streak_section',
+        (tester) async {
+      await tester.pumpWidget(
+        _wrap(WinOverlay(
+          onPlayAgain: () {},
+          onNewPuzzle: () {},
+          streakRecord: StreakRecord.initial(),
+        )),
+      );
+      await tester.pump();
+
+      expect(find.textContaining('Day Streak'), findsNothing,
+          reason: 'streak section must not appear when currentStreak == 0');
+    });
+
+    testWidgets('given_streak_of_5_when_rendered_then_shows_current_streak', (tester) async {
+      await tester.pumpWidget(
+        _wrap(WinOverlay(
+          onPlayAgain: () {},
+          onNewPuzzle: () {},
+          streakRecord: const StreakRecord(
+            currentStreak: 5,
+            longestStreak: 12,
+            lastCompletionDate: '2026-06-27',
+          ),
+        )),
+      );
+      await tester.pump();
+
+      expect(find.textContaining('5'), findsWidgets,
+          reason: 'current streak count must be visible');
+      expect(find.textContaining('Day Streak'), findsOneWidget,
+          reason: 'streak label must appear when currentStreak > 0');
+    });
+
+    testWidgets('given_streak_record_when_rendered_then_shows_longest_streak', (tester) async {
+      await tester.pumpWidget(
+        _wrap(WinOverlay(
+          onPlayAgain: () {},
+          onNewPuzzle: () {},
+          streakRecord: const StreakRecord(
+            currentStreak: 3,
+            longestStreak: 10,
+            lastCompletionDate: '2026-06-27',
+          ),
+        )),
+      );
+      await tester.pump();
+
+      expect(find.textContaining('10'), findsWidgets,
+          reason: 'longest streak must be shown alongside current streak');
+    });
+
+    testWidgets('given_streak_of_1_when_rendered_then_streak_section_is_visible',
+        (tester) async {
+      await tester.pumpWidget(
+        _wrap(WinOverlay(
+          onPlayAgain: () {},
+          onNewPuzzle: () {},
+          streakRecord: const StreakRecord(
+            currentStreak: 1,
+            longestStreak: 1,
+            lastCompletionDate: '2026-06-27',
+          ),
+        )),
+      );
+      await tester.pump();
+
+      expect(find.textContaining('Day Streak'), findsOneWidget);
     });
   });
 }

--- a/test/widget/game_screen_loaded_test.dart
+++ b/test/widget/game_screen_loaded_test.dart
@@ -881,6 +881,57 @@ void main() {
     await tester.binding.setSurfaceSize(null);
   });
 
+  testWidgets('winning the game records streak in SharedPreferences', (tester) async {
+    await tester.binding.setSurfaceSize(const Size(1280, 800));
+    await tester.pumpWidget(_wrap(GameScreen(
+      selectedImage: _testImage,
+      gridSize: 1,
+      difficultyStars: 1,
+      localeNotifier: _makeLocaleNotifier(),
+      hintSettings: _makeHintSettings(),
+    )));
+    await tester.pump();
+    await _pumpUntilPlaying(tester);
+
+    await _placeLastPiece(tester);
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 5, milliseconds: 100));
+    await tester.pump();
+
+    // After winning, StreakService.recordPuzzleCompletion() must have been called,
+    // storing streak_current = 1 in SharedPreferences.
+    final prefs = await SharedPreferences.getInstance();
+    expect(prefs.getInt('streak_current'), 1,
+        reason: 'winning a puzzle must persist streak_current = 1');
+
+    await tester.binding.setSurfaceSize(null);
+  });
+
+  testWidgets('win overlay shows streak text after puzzle completion', (tester) async {
+    await tester.binding.setSurfaceSize(const Size(1280, 800));
+    await tester.pumpWidget(_wrap(GameScreen(
+      selectedImage: _testImage,
+      gridSize: 1,
+      difficultyStars: 1,
+      localeNotifier: _makeLocaleNotifier(),
+      hintSettings: _makeHintSettings(),
+    )));
+    await tester.pump();
+    await _pumpUntilPlaying(tester);
+
+    await _placeLastPiece(tester);
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 5, milliseconds: 100));
+    await tester.pump();
+
+    expect(find.byType(WinOverlay), findsOneWidget);
+    // After winning, the overlay must show streak information.
+    expect(find.textContaining('Day Streak'), findsOneWidget,
+        reason: 'win overlay must display the current streak after completion');
+
+    await tester.binding.setSurfaceSize(null);
+  });
+
   testWidgets('tapping New Puzzle from win overlay invokes onNewPuzzle',
       (tester) async {
     await tester.binding.setSurfaceSize(const Size(1280, 800));

--- a/test/widget/settings_screen_test.dart
+++ b/test/widget/settings_screen_test.dart
@@ -3,9 +3,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:lily_jigsaw_puzzle/l10n/app_localizations.dart';
 import 'package:lily_jigsaw_puzzle/main.dart';
+import 'package:lily_jigsaw_puzzle/models/streak_record.dart';
 import 'package:lily_jigsaw_puzzle/screens/settings_screen.dart';
 import 'package:lily_jigsaw_puzzle/services/difficulty_settings_service.dart';
 import 'package:lily_jigsaw_puzzle/services/hint_settings_service.dart';
+import 'package:lily_jigsaw_puzzle/services/streak_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 LocaleNotifier _makeLocaleNotifier() => LocaleNotifier(const Locale('en'));
@@ -437,6 +439,45 @@ void main() {
     await tester.pump();
 
     expect(hs.immediateMode, isTrue);
+    await tester.binding.setSurfaceSize(null);
+  });
+
+  testWidgets(
+      'given_existing_streak_when_reset_progress_tapped_then_streak_data_is_cleared',
+      (tester) async {
+    await tester.binding.setSurfaceSize(const Size(800, 1200));
+
+    // Pre-populate streak data in SharedPreferences.
+    SharedPreferences.setMockInitialValues({
+      'streak_current': 5,
+      'streak_longest': 10,
+      'streak_last_date': '2026-06-01',
+    });
+
+    await tester.pumpWidget(
+      _wrap(SettingsScreen(
+        localeNotifier: _makeLocaleNotifier(),
+        difficultySettings: _makeDifficultySettings(),
+        hintSettings: _makeHintSettings(),
+      )),
+    );
+    await tester.pump();
+
+    // Unlock the settings panel.
+    await _unlockSettings(tester);
+
+    // Scroll to reveal the Reset Progress button, then tap it.
+    final resetButton = find.byIcon(Icons.delete_sweep_rounded).first;
+    await tester.ensureVisible(resetButton);
+    await tester.pump();
+    await tester.tap(resetButton);
+    await tester.pump();
+
+    // After reset, StreakService should report initial state.
+    final record = await StreakService().getStreak();
+    expect(record, StreakRecord.initial(),
+        reason: 'Reset Progress must clear all streak data');
+
     await tester.binding.setSurfaceSize(null);
   });
 }


### PR DESCRIPTION
## Summary

- Adds a **daily puzzle streak** that counts how many consecutive calendar days the user completed at least one puzzle — not just launched the app
- Streak is persisted via `shared_preferences` (already in the project — no new dependencies)
- Win overlay shows "🔥 N Day Streak" and personal best after every puzzle completion
- Reset Progress in Settings also clears streak data

## Key design decisions

- **`StreakRecord`** — immutable value object (`@immutable`, `==`/`hashCode`, `copyWith`)
- **`StreakService`** — clock injection (`DateTime Function()? clock`) for deterministic tests; same SharedPreferences pattern as existing `CompletionService`
- **Transition rules**: first-ever → 1; same-day → idempotent; consecutive → +1; gap → reset to 1 (longest streak preserved)
- Streak threaded through `GameBoardView` to `WinOverlay` as a nullable `StreakRecord?` — backward-compatible, no callers broken
- `WinOverlay` shows streak section only when `currentStreak > 0`; localized in all 4 languages (EN/PL/DE/ES)

## Test plan

- [x] `flutter test` — 403 tests, all pass (22 new unit + 3 new widget tests)
- [x] `flutter analyze` — zero issues
- [x] `flutter build apk --debug` — clean build
- [x] TDD followed: tests written and confirmed failing before each implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)