### PR TITLE
chore: enforce LF line endings via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+# Enforce LF line endings for all text files in this repository.
+# Overrides core.autocrlf on Windows/WSL2 checkouts.
+* text=auto eol=lf
+
+# Explicitly binary — never touch line endings
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.apk binary
+*.aab binary
+*.jar binary
+*.class binary
+*.keystore binary


### PR DESCRIPTION
## Summary

- Adds `.gitattributes` with `* text=auto eol=lf` to enforce Unix line endings across the repo
- Marks binary assets (images, APK, JAR, keystore) explicitly so git never touches them
- Fixes root cause of CRLF line endings appearing on WSL2 checkouts (`core.autocrlf=true`)

## Why

`core.autocrlf=true` was set in the local git config, causing every text file checked out on the WSL2 dev machine to have `\r\n` line endings. This silently broke the Edit tool's exact-match (CRLF in file vs LF in `old_string`) and produced "LF will be replaced by CRLF" warnings on every commit.

A per-repo `.gitattributes` with `eol=lf` overrides `core.autocrlf` and ensures all contributors (and CI) see consistent LF regardless of their OS setting.

## Test plan

- [ ] Verify `file CLAUDE.md` reports `UTF-8 Unicode text` (no "CRLF" suffix) after checkout
- [ ] Confirm no "LF will be replaced by CRLF" warnings appear on subsequent commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)