### PR TITLE
fix: prevent duplicate Claude review inline comments

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,60 +39,84 @@ jobs:
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
-            ## Step 1 — Fetch existing bot comments
+            ## Step 1 — Load prior inline review comments
 
-            Fetch all existing PR-level summary comments posted by the GitHub App bot and save
-            their IDs — you will replace exactly one of them later:
-
-            ```
-            gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments \
-              --jq '.[] | select(.performed_via_github_app != null) | {id, body}'
-            ```
-
-            Fetch all existing bot-posted inline review comments and save them as your
-            **prior-comments list** (id, path, line, body):
+            Fetch every existing inline review comment on this PR and save the full list as
+            **PRIOR_INLINE** (fields: id, path, line, original_line, body). These are comments
+            previously posted by this bot that may or may not still be relevant.
 
             ```
             gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments \
-              --jq '.[] | select(.performed_via_github_app != null) | {id, path, line, original_line, body}'
+              --jq '[.[] | select(.user.type == "Bot" or (.performed_via_github_app != null)) | {id, path, line, original_line, body}]'
             ```
 
-            ## Step 2 — Fetch the current diff
+            Also fetch every existing PR-level (issue) comment and save as **PRIOR_SUMMARY**
+            (fields: id, body):
+
+            ```
+            gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments \
+              --jq '[.[] | select(.user.type == "Bot" or (.performed_via_github_app != null)) | {id, body}]'
+            ```
+
+            ## Step 2 — Fetch and parse the current diff
 
             ```
             gh pr diff ${{ github.event.pull_request.number }}
             ```
 
-            Parse the diff to build a map of **currently changed lines**: for each `+` line,
-            record its file path and position/line number. Lines that no longer appear as `+`
-            in the diff have been removed or fixed in the latest commit.
+            Build a **CHANGED_LINES** map: for every `+` line in the diff record its file path
+            and line number. Only `+` lines are reviewable; context and `-` lines are not.
 
-            ## Step 3 — Reconcile inline comments
+            ## Step 3 — Reconcile prior inline comments
 
-            Go through every comment in the **prior-comments list** one by one:
+            Iterate over every entry in **PRIOR_INLINE** one by one and decide what to do:
 
-            a. **Check if the issue still exists.**
-               - Look at the file + line the comment references.
-               - Read the current content of that line in the diff (or the checked-out file).
-               - If the code that caused the issue is **gone or fixed** → the comment is stale.
-               - If the same problematic code is **still present** → the comment is still valid.
+            ### 3a — Check if the issue was fixed
 
-            b. **Act accordingly:**
-               - **Stale comment** (issue fixed): delete it.
-                 `gh api repos/${{ github.repository }}/pulls/comments/{id} -X DELETE`
-               - **Still-valid comment** (issue not fixed): keep it as-is. Do NOT delete and
-                 re-create it. Only update it if the line number shifted significantly due to
-                 surrounding changes (use PATCH to update the body noting the line moved).
+            - Look up the file + line from the prior comment in **CHANGED_LINES**.
+            - Read the actual current content of that line (from the diff or the checked-out file).
+            - **Fixed / no longer present**: the problematic code is gone, the line was deleted,
+              or the file no longer exists in the diff.
+            - **Still an issue**: the same problematic code is present at or near that line.
 
-            c. **New issues** found in the diff that have no existing inline comment:
-               post a new inline comment using `mcp__github_inline_comment__create_inline_comment`.
-               Each new inline comment must:
-               - Reference the exact file path and line number from the diff (`+` lines only).
-               - Briefly explain the issue and suggest a concrete improvement.
-               - Only be posted when you are confident there is a real violation of the rules
-                 below — do not post trivial or purely stylistic notes.
+            ### 3b — Act on the decision
 
-            ### Review rules to apply to the diff
+            **If fixed** — mark the thread resolved before removing it:
+
+            1. Post a reply on the comment thread to record that the fix was seen:
+               ```
+               gh api repos/${{ github.repository }}/pulls/comments/{id}/replies \
+                 -X POST -f body="✅ Fixed in the latest commit — closing this thread."
+               ```
+            2. Then delete the original comment:
+               ```
+               gh api repos/${{ github.repository }}/pulls/comments/{id} -X DELETE
+               ```
+
+            **If still an issue** — leave the existing comment completely untouched.
+            Do NOT delete it. Do NOT create any new comment for the same location.
+            The existing comment already represents this finding.
+
+            ## Step 4 — Post new inline comments for new issues only
+
+            Review the diff for violations of the rules listed below.
+
+            For every issue you find, **before calling `mcp__github_inline_comment__create_inline_comment`**,
+            run this mandatory deduplication check:
+
+            > Search **PRIOR_INLINE** for any entry whose `path` matches the file AND whose
+            > `line` (or `original_line`) is within ±3 lines of the issue you are about to report.
+            > If such an entry exists, **skip** — do not post a new comment.
+            > Only call `mcp__github_inline_comment__create_inline_comment` when no prior comment
+            > covers that location.
+
+            Each new inline comment must:
+            - Reference the exact file path and line number from the diff (`+` lines only).
+            - Briefly explain the issue and suggest a concrete fix.
+            - Only be posted when you are confident there is a real violation — no trivial or
+              purely stylistic notes.
+
+            ### Review rules
 
             #### Code Quality
             - Code follows the Dart style guide and project conventions
@@ -119,32 +143,29 @@ jobs:
             - Proper error handling
             - No sensitive data in logs
 
-            ## Step 4 — Replace the summary comment (always at the bottom)
+            ## Step 5 — Replace the summary comment
 
-            Delete every previous bot-posted summary comment found in Step 1 so the new one
-            appears at the bottom of the conversation:
+            Delete every comment in **PRIOR_SUMMARY** so the new one appears at the bottom:
 
             ```
-            # for each id from Step 1:
+            # for each id in PRIOR_SUMMARY:
             gh api repos/${{ github.repository }}/issues/comments/{id} -X DELETE
             ```
 
             Write a concise review summary to `review.md` and post it:
+
             ```
             gh pr comment ${{ github.event.pull_request.number }} --body-file review.md
             ```
 
             The summary must:
             - Start with an overall verdict: **Approved**, **Approved with suggestions**, or **Changes requested**
-            - List only checklist items that need attention (skip items that pass)
-            - Note which previously raised issues were fixed in the latest commit
+            - List only items that need attention (skip items that pass)
+            - Mention which previously raised issues were fixed in the latest commit
             - Cross-reference remaining inline comments (e.g., "see inline comment in `lib/foo.dart`")
             - Be concise — aim for under 30 lines
 
-            ## Step 5 — Submit a formal PR review
-
-            After posting the summary comment, submit a GitHub review so the verdict is
-            reflected in the PR's review status (green checkmark or blocking review):
+            ## Step 6 — Submit a formal PR review
 
             - **No issues found**: approve the PR
               `gh pr review ${{ github.event.pull_request.number }} --approve --body "LGTM — no issues found."`
@@ -153,9 +174,8 @@ jobs:
             - **Issues that must be fixed**: request changes
               `gh pr review ${{ github.event.pull_request.number }} --request-changes --body "Changes requested — see inline comments and summary."`
 
-            Use **request-changes** only when there is a clear violation of the rules in Step 3
-            (e.g. missing tests for new code, hardcoded secrets, broken SOLID/DRY/KISS rules).
-            Use **approve** for everything else, including minor style suggestions.
+            Use **request-changes** only for clear violations: missing tests for new code,
+            hardcoded secrets, broken SOLID/DRY/KISS rules. Use **approve** for everything else.
 
             **CRITICAL RULE:** Do NOT modify any existing repository files. You may ONLY write to `review.md`.
 


### PR DESCRIPTION
## Summary

- **Explicit deduplication gate**: before posting any new inline comment, Claude must search `PRIOR_INLINE` for an existing comment at the same path ± 3 lines and skip if one is found
- **Mark resolved on fix**: when a prior comment's issue is addressed, Claude posts a "✅ Fixed in the latest commit" reply before deleting the original — fix is visible in thread history
- **Better bot detection**: jq filter changed from `performed_via_github_app != null` to `user.type == "Bot" or performed_via_github_app != null` to reliably catch all previous bot comments

## Root cause

The previous prompt told Claude to "keep as-is" a still-valid prior comment, but did not explicitly block posting a *new* comment at the same location. By the time Claude reviewed a file, the connection between the prior-comments list and the current finding was lost, resulting in duplicates accumulating with each re-run.

## Test plan

- [ ] Push a PR with a code issue → Claude posts one inline comment
- [ ] Push a new commit without fixing the issue → no duplicate comment appears
- [ ] Fix the issue and push → Claude replies "✅ Fixed" and removes the original inline comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)