### PR TITLE
chore: fix Renovate config to prevent incompatible dependency PRs

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   google_fonts: 8.1.0
-  intl: 0.20.2
+  intl: ^0.20.2
   shared_preferences: 2.5.5
   uuid: 4.5.3
 

--- a/renovate.json
+++ b/renovate.json
@@ -10,35 +10,36 @@
   "minimumReleaseAge": "3 days",
   "internalChecksFilter": "strict",
   "ignoreUnstable": true,
-  "rangeStrategy": "pin",
+  "rangeStrategy": "bump",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^\\.github/workflows/[^/]+\\.ya?ml$"],
+      "matchStrings": ["flutter-version:\\s+'(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)'"],
+      "depNameTemplate": "flutter",
+      "datasourceTemplate": "flutter-version",
+      "versioningTemplate": "semver"
+    }
+  ],
   "packageRules": [
     {
-      "description": "Group Flutter and Dart SDK updates together for compatibility",
-      "matchPackageNames": [
-        "flutter",
-        "dart"
-      ],
-      "groupName": "Flutter and Dart SDK",
-      "schedule": [
-        "on sunday"
-      ]
+      "description": "Disable intl updates — version is pinned by flutter_localizations to match the bundled Flutter SDK version; managed via ^range in pubspec.yaml",
+      "matchPackageNames": ["intl"],
+      "enabled": false
     },
     {
-      "description": "Group pub.dev dependency updates",
-      "matchDatasources": [
-        "pub"
-      ],
-      "groupName": "pub.dev dependencies"
+      "description": "Group all pub.dev packages and the CI flutter-version together so they always move as one compatible set. Packages like audioplayers or very_good_analysis may require a newer Flutter/Dart — updating them atomically with the CI SDK version prevents incompatibility failures.",
+      "matchManagers": ["pub", "regex"],
+      "excludePackageNames": ["intl"],
+      "groupName": "Flutter and dependencies",
+      "schedule": ["on sunday"],
+      "rangeStrategy": "bump"
     },
     {
-      "description": "Group GitHub Actions updates",
-      "matchManagers": [
-        "github-actions"
-      ],
+      "description": "Group GitHub Actions updates (action version tags, not flutter-version inputs which are handled above)",
+      "matchManagers": ["github-actions"],
       "groupName": "GitHub Actions",
-      "schedule": [
-        "on sunday"
-      ]
+      "schedule": ["on sunday"]
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Adds a custom regex manager so Renovate tracks `flutter-version:` in CI workflow files — previously it wasn't managing this at all, which is why packages requiring a newer Flutter were proposed without ever bumping the SDK in CI
- Groups all pub.dev packages and the CI `flutter-version` into one atomic **"Flutter and dependencies"** PR (weekly, on Sunday), so packages like `audioplayers` or `very_good_analysis` that require a newer Flutter always move together with the Flutter upgrade
- Disables `intl` updates — `flutter_localizations` pins `intl` to a specific version matching the bundled Flutter SDK, so independent `intl` bumps always fail; also relaxes `intl: 0.20.2` → `intl: ^0.20.2` in pubspec.yaml so the lockfile can accommodate the SDK-pinned version without a hard conflict
- Changes `rangeStrategy` from `pin` to `bump` so the Dart SDK environment constraint stays as a range (`^x.y.z`) instead of being pinned to an exact version the current CI Flutter can't satisfy

## Root cause of the 4 failing PRs

All failing PRs (#116, #113, #125, #122) required Flutter ≥ 3.44.4 / Dart 3.12.x but CI was pinned to Flutter 3.41.3 (Dart 3.11.1). Renovate was proposing each package independently with no awareness of the Flutter SDK version requirement.

## Test plan

- [x] `flutter test` — 403 tests pass
- [x] `flutter analyze` — no issues
- [x] `flutter build apk --debug` — builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)