### PR TITLE
refactor: remove dead code and simplify (ponytail audit)

### DIFF
--- a/lib/core/app_theme.dart
+++ b/lib/core/app_theme.dart
@@ -28,7 +28,7 @@ abstract final class AppColors {
   /// Sunny yellow shadow — 3-D base for yellow buttons.
   static const Color sunnyYellowShadow = Color(0xFFD4B830);
 
-  // ── Legacy aliases kept for call-sites not yet updated ───────────────────
+  // ── Additional colours ────────────────────────────────────────────────────
 
   /// Deep purple — text strokes, outlines.
   static const Color deepPurple = Color(0xFF5B2D8E);
@@ -36,20 +36,11 @@ abstract final class AppColors {
   /// Medium purple — settings / secondary buttons.
   static const Color mediumPurple = Color(0xFF9B6DD4);
 
-  /// Hot pink — legacy accent.
-  static const Color hotPink = pastelPink;
-
   /// Lavender — midpoint of background gradient.
   static const Color lavender = Color(0xFFCEB4F0);
 
   /// Baby pink — bottom of background gradient.
   static const Color babyPink = Color(0xFFFFCCE5);
-
-  /// Green — maps to mint for confirm/easy.
-  static const Color green = mintGreen;
-
-  /// Dark green — shadow for green.
-  static const Color greenShadow = mintGreenShadow;
 
   /// Red — quit / destructive actions.
   static const Color red = Color(0xFFFF7BAC);
@@ -57,23 +48,8 @@ abstract final class AppColors {
   /// Dark red — shadow for red buttons.
   static const Color redShadow = Color(0xFFCC4480);
 
-  /// Orange — medium difficulty.
-  static const Color orange = sunnyYellow;
-
-  /// Dark orange — shadow for orange.
-  static const Color orangeShadow = sunnyYellowShadow;
-
-  /// Blue — navigation buttons.
-  static const Color blue = skyBlue;
-
-  /// Dark blue — shadow for blue.
-  static const Color blueShadow = skyBlueShadow;
-
   /// Gold — star icons.
   static const Color gold = Color(0xFFFFD700);
-
-  /// Amber — hint button.
-  static const Color amber = sunnyYellow;
 }
 
 /// Shared decoration constants.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -77,7 +77,7 @@ class JigsawApp extends StatelessWidget {
           supportedLocales: AppLocalizations.supportedLocales,
           theme: ThemeData(
             colorScheme: ColorScheme.fromSeed(
-              seedColor: AppColors.hotPink,
+              seedColor: AppColors.pastelPink,
             ),
             useMaterial3: true,
             textTheme: GoogleFonts.nunitoTextTheme(),

--- a/lib/models/puzzle_builder.dart
+++ b/lib/models/puzzle_builder.dart
@@ -8,8 +8,7 @@ import 'package:lily_jigsaw_puzzle/models/puzzle_piece.dart';
 ///
 /// Randomly assigns tab/blank connector shapes to all shared edges so adjacent
 /// pieces interlock correctly.
-class PuzzleBuilder {
-  PuzzleBuilder._();
+abstract final class PuzzleBuilder {
 
   /// Builds [gridSize]² pieces positioned within [boardSize] at [boardOffset].
   ///

--- a/lib/models/puzzle_image.dart
+++ b/lib/models/puzzle_image.dart
@@ -1,35 +1,20 @@
-import 'package:uuid/uuid.dart';
-
-class PuzzleImageData { // deterministic UUID generated from asset path
-
+class PuzzleImageData {
   const PuzzleImageData({
     required this.assetPath,
-    required this.name,
     required this.uuid,
   });
   final String assetPath;
-  final String name; // fallback English name
   final String uuid;
 
-  // Private namespace UUID used for v5 generation (arbitrary, stable).
-  static const _ns = '3c3d63d7-0de7-4b57-8e7f-a9a1b9c2d7e5';
-
-  static final List<PuzzleImageData> all = _buildAll();
-
-  static List<PuzzleImageData> _buildAll() {
-    const uuidGen = Uuid();
-    String id(String path) => uuidGen.v5(_ns, path);
-
-    return [
-      PuzzleImageData(assetPath: 'assets/images/puzzle-1.jpg', name: 'Cat',      uuid: id('assets/images/puzzle-1.jpg')),
-      PuzzleImageData(assetPath: 'assets/images/puzzle-2.jpg', name: 'Dog',      uuid: id('assets/images/puzzle-2.jpg')),
-      PuzzleImageData(assetPath: 'assets/images/puzzle-3.jpg', name: 'Forest',   uuid: id('assets/images/puzzle-3.jpg')),
-      PuzzleImageData(assetPath: 'assets/images/puzzle-4.jpg', name: 'City',     uuid: id('assets/images/puzzle-4.jpg')),
-      PuzzleImageData(assetPath: 'assets/images/puzzle-5.jpg', name: 'Lion',     uuid: id('assets/images/puzzle-5.jpg')),
-      PuzzleImageData(assetPath: 'assets/images/puzzle-6.jpg', name: 'Sea',      uuid: id('assets/images/puzzle-6.jpg')),
-      PuzzleImageData(assetPath: 'assets/images/puzzle-7.jpg', name: 'Elephant', uuid: id('assets/images/puzzle-7.jpg')),
-      PuzzleImageData(assetPath: 'assets/images/puzzle-8.jpg', name: 'Squirrel', uuid: id('assets/images/puzzle-8.jpg')),
-      PuzzleImageData(assetPath: 'assets/images/puzzle-9.jpg', name: 'Hedgehog', uuid: id('assets/images/puzzle-9.jpg')),
-    ];
-  }
+  static const List<PuzzleImageData> all = [
+    PuzzleImageData(assetPath: 'assets/images/puzzle-1.jpg', uuid: 'c9ca2678-81e7-5268-b01c-551c354b2f70'),
+    PuzzleImageData(assetPath: 'assets/images/puzzle-2.jpg', uuid: 'c72cd81d-b06d-5b5f-a68a-392b1757002c'),
+    PuzzleImageData(assetPath: 'assets/images/puzzle-3.jpg', uuid: 'f45c886a-9f8b-5c7c-b79d-333930fc17cd'),
+    PuzzleImageData(assetPath: 'assets/images/puzzle-4.jpg', uuid: 'd5ba0e08-5414-59b9-9f48-9cff6ac3152d'),
+    PuzzleImageData(assetPath: 'assets/images/puzzle-5.jpg', uuid: '8c6d49ba-d76b-5087-9f86-32bbd27a94d1'),
+    PuzzleImageData(assetPath: 'assets/images/puzzle-6.jpg', uuid: '0421fcde-de78-5546-9e5d-98baa049268c'),
+    PuzzleImageData(assetPath: 'assets/images/puzzle-7.jpg', uuid: '9d8afb59-3130-5fc0-b3bd-1f30e1925a99'),
+    PuzzleImageData(assetPath: 'assets/images/puzzle-8.jpg', uuid: '7cadc4ed-659b-5795-8595-1f623552e1c0'),
+    PuzzleImageData(assetPath: 'assets/images/puzzle-9.jpg', uuid: '55064576-fba7-5884-92f2-e63a85899524'),
+  ];
 }

--- a/lib/models/puzzle_image.dart
+++ b/lib/models/puzzle_image.dart
@@ -6,6 +6,9 @@ class PuzzleImageData {
   final String assetPath;
   final String uuid;
 
+  /// UUIDs are UUID v5 values computed from each asset path using namespace
+  /// `3c3d63d7-0de7-4b57-8e7f-a9a1b9c2d7e5` (via the `uuid` package's
+  /// `Uuid().v5(ns, assetPath)`). Add new entries the same way.
   static const List<PuzzleImageData> all = [
     PuzzleImageData(assetPath: 'assets/images/puzzle-1.jpg', uuid: 'c9ca2678-81e7-5268-b01c-551c354b2f70'),
     PuzzleImageData(assetPath: 'assets/images/puzzle-2.jpg', uuid: 'c72cd81d-b06d-5b5f-a68a-392b1757002c'),

--- a/lib/screens/difficulty_sliders_section.dart
+++ b/lib/screens/difficulty_sliders_section.dart
@@ -43,7 +43,7 @@ class DifficultySlidersSection extends StatelessWidget {
             children: [
               _buildSliderRow(
                 label: l10n.easy,
-                color: AppColors.green,
+                color: AppColors.mintGreen,
                 value: easy,
                 min: DifficultySettings.minGridSize,
                 max: medium - 1,
@@ -52,7 +52,7 @@ class DifficultySlidersSection extends StatelessWidget {
               const SizedBox(height: 8),
               _buildSliderRow(
                 label: l10n.medium,
-                color: AppColors.orange,
+                color: AppColors.sunnyYellow,
                 value: medium,
                 min: easy + 1,
                 max: hard - 1,

--- a/lib/screens/game_board_view.dart
+++ b/lib/screens/game_board_view.dart
@@ -213,10 +213,10 @@ class GameBoardView extends StatelessWidget {
               begin: Alignment.topCenter,
               end: Alignment.bottomCenter,
               colors: [
-                AppColors.hotPink,
+                AppColors.pastelPink,
                 Color(0xFFFFD93D),
-                AppColors.green,
-                AppColors.blue,
+                AppColors.mintGreen,
+                AppColors.skyBlue,
               ],
             ),
             boxShadow: [

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -305,7 +305,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
             Container(
               padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
               decoration: BoxDecoration(
-                color: AppColors.green.withValues(alpha: 0.90),
+                color: AppColors.mintGreen.withValues(alpha: 0.90),
                 borderRadius: BorderRadius.circular(12),
               ),
               child: Text(

--- a/lib/services/streak_service.dart
+++ b/lib/services/streak_service.dart
@@ -41,7 +41,7 @@ class StreakService {
   /// - Gap of 2+ days → streak resets to 1; [StreakRecord.longestStreak] is preserved.
   Future<StreakRecord> recordPuzzleCompletion() async {
     final existing = await getStreak();
-    final today = _toDateString(_clock());
+    final today = _clock().toIso8601String().split('T').first;
     final next = _transition(existing, today);
     if (next != existing) {
       await _persist(next);
@@ -97,12 +97,9 @@ class StreakService {
     }
   }
 
-  String _toDateString(DateTime dt) =>
-      '${dt.year.toString().padLeft(4, '0')}'
-      '-${dt.month.toString().padLeft(2, '0')}'
-      '-${dt.day.toString().padLeft(2, '0')}';
-
-  String _yesterday(String isoDate) => _toDateString(
-        DateTime.parse(isoDate).subtract(const Duration(days: 1)),
-      );
+  String _yesterday(String isoDate) => DateTime.parse(isoDate)
+      .subtract(const Duration(days: 1))
+      .toIso8601String()
+      .split('T')
+      .first;
 }

--- a/lib/widgets/win_overlay.dart
+++ b/lib/widgets/win_overlay.dart
@@ -65,13 +65,13 @@ class WinOverlay extends StatelessWidget {
               ),
               boxShadow: [
                 BoxShadow(
-                  color: AppColors.hotPink.withValues(alpha: 0.50),
+                  color: AppColors.pastelPink.withValues(alpha: 0.50),
                   blurRadius: 30,
                   offset: const Offset(0, 10),
                 ),
               ],
               border: Border.all(
-                color: AppColors.hotPink.withValues(alpha: 0.50),
+                color: AppColors.pastelPink.withValues(alpha: 0.50),
                 width: 2.5,
               ),
             ),
@@ -97,7 +97,7 @@ class WinOverlay extends StatelessWidget {
                     style: TextStyle(
                       fontSize: compact ? 16.0 : 20.0,
                       fontWeight: FontWeight.w800,
-                      color: AppColors.hotPink,
+                      color: AppColors.pastelPink,
                     ),
                   ),
                   Text(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,6 @@ dependencies:
   google_fonts: 8.1.0
   intl: ^0.20.2
   shared_preferences: 2.5.5
-  uuid: 4.5.3
 
 dev_dependencies:
   flutter_launcher_icons: 0.14.4

--- a/test/core/app_theme_test.dart
+++ b/test/core/app_theme_test.dart
@@ -12,8 +12,8 @@ void main() {
       expect(AppColors.mediumPurple, const Color(0xFF9B6DD4));
     });
 
-    test('hotPink is pastelPink Color(0xFFFA9AC1)', () {
-      expect(AppColors.hotPink, const Color(0xFFFA9AC1));
+    test('pastelPink is Color(0xFFFA9AC1)', () {
+      expect(AppColors.pastelPink, const Color(0xFFFA9AC1));
     });
 
     test('skyBlue is Color(0xFF80D4F7)', () {
@@ -28,16 +28,16 @@ void main() {
       expect(AppColors.babyPink, const Color(0xFFFFCCE5));
     });
 
-    test('green is mintGreen Color(0xFF99EEC4)', () {
-      expect(AppColors.green, const Color(0xFF99EEC4));
+    test('mintGreen is Color(0xFF99EEC4)', () {
+      expect(AppColors.mintGreen, const Color(0xFF99EEC4));
     });
 
     test('red is Color(0xFFFF7BAC)', () {
       expect(AppColors.red, const Color(0xFFFF7BAC));
     });
 
-    test('blue is skyBlue Color(0xFF80D4F7)', () {
-      expect(AppColors.blue, const Color(0xFF80D4F7));
+    test('sunnyYellow is Color(0xFFFEE668)', () {
+      expect(AppColors.sunnyYellow, const Color(0xFFFEE668));
     });
 
     test('gold is Color(0xFFFFD700)', () {

--- a/test/unit/models/puzzle_image_test.dart
+++ b/test/unit/models/puzzle_image_test.dart
@@ -7,12 +7,6 @@ void main() {
       expect(PuzzleImageData.all.length, 9);
     });
 
-    test('all items have non-empty names', () {
-      for (final img in PuzzleImageData.all) {
-        expect(img.name.isNotEmpty, isTrue);
-      }
-    });
-
     test('all items have asset paths under assets/images/', () {
       for (final img in PuzzleImageData.all) {
         expect(img.assetPath.startsWith('assets/images/'), isTrue);
@@ -24,24 +18,12 @@ void main() {
       expect(paths.toSet().length, paths.length);
     });
 
-    test('all names are unique', () {
-      final names = PuzzleImageData.all.map((e) => e.name).toList();
-      expect(names.toSet().length, names.length);
-    });
-
-    test('contains expected puzzle names', () {
-      final names = PuzzleImageData.all.map((e) => e.name).toSet();
-      expect(names, containsAll(['Cat', 'Dog', 'Lion']));
-    });
-
     test('constructor stores values correctly', () {
       const img = PuzzleImageData(
         assetPath: 'assets/test.jpg',
-        name: 'Test',
         uuid: 'test-uuid-1234',
       );
       expect(img.assetPath, 'assets/test.jpg');
-      expect(img.name, 'Test');
       expect(img.uuid, 'test-uuid-1234');
     });
 

--- a/test/widget/game_screen_loaded_test.dart
+++ b/test/widget/game_screen_loaded_test.dart
@@ -26,7 +26,6 @@ Widget _wrap(Widget child) => MaterialApp(
 
 const _testImage = PuzzleImageData(
   assetPath: 'assets/images/puzzle-1.jpg',
-  name: 'Cat',
   uuid: 'test-uuid-cat',
 );
 

--- a/test/widget/game_screen_test.dart
+++ b/test/widget/game_screen_test.dart
@@ -22,7 +22,6 @@ Widget _wrap(Widget child) => MaterialApp(
 
 const _testImage = PuzzleImageData(
   assetPath: 'assets/images/puzzle-1.jpg',
-  name: 'Cat',
   uuid: 'test-uuid-cat',
 );
 

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -88,7 +88,6 @@ void main() {
       _wrap(DifficultyScreen(
         selectedImage: const PuzzleImageData(
           assetPath: 'assets/images/puzzle-1.jpg',
-          name: 'Cat',
           uuid: 'test-uuid-cat',
         ),
         localeNotifier: _makeLocaleNotifier(),
@@ -107,7 +106,6 @@ void main() {
       _wrap(DifficultyScreen(
         selectedImage: const PuzzleImageData(
           assetPath: 'assets/images/puzzle-1.jpg',
-          name: 'Cat',
           uuid: 'test-uuid-cat',
         ),
         localeNotifier: _makeLocaleNotifier(),
@@ -124,7 +122,6 @@ void main() {
       _wrap(DifficultyScreen(
         selectedImage: const PuzzleImageData(
           assetPath: 'assets/images/puzzle-1.jpg',
-          name: 'Cat',
           uuid: 'test-uuid-cat',
         ),
         localeNotifier: _makeLocaleNotifier(),
@@ -242,7 +239,6 @@ void main() {
       _wrap(DifficultyScreen(
         selectedImage: const PuzzleImageData(
           assetPath: 'assets/images/puzzle-1.jpg',
-          name: 'Cat',
           uuid: 'test-uuid-cat',
         ),
         localeNotifier: _makeLocaleNotifier(),
@@ -260,7 +256,6 @@ void main() {
       _wrap(DifficultyScreen(
         selectedImage: const PuzzleImageData(
           assetPath: 'assets/images/puzzle-1.jpg',
-          name: 'Cat',
           uuid: 'test-uuid-cat',
         ),
         localeNotifier: _makeLocaleNotifier(),
@@ -281,7 +276,6 @@ void main() {
       _wrap(DifficultyScreen(
         selectedImage: const PuzzleImageData(
           assetPath: 'assets/images/puzzle-1.jpg',
-          name: 'Cat',
           uuid: 'test-uuid-cat',
         ),
         localeNotifier: _makeLocaleNotifier(),
@@ -346,7 +340,6 @@ void main() {
     SharedPreferences.setMockInitialValues({});
     const catImage = PuzzleImageData(
       assetPath: 'assets/images/puzzle-1.jpg',
-      name: 'Cat',
       uuid: 'test-uuid-cat',
     );
     // Record 3-star completion to unlock Hard
@@ -378,7 +371,6 @@ void main() {
       _wrap(DifficultyScreen(
         selectedImage: const PuzzleImageData(
           assetPath: 'assets/images/puzzle-1.jpg',
-          name: 'Cat',
           uuid: 'test-uuid-cat',
         ),
         localeNotifier: _makeLocaleNotifier(),
@@ -427,7 +419,6 @@ void main() {
       _wrap(DifficultyScreen(
         selectedImage: const PuzzleImageData(
           assetPath: 'assets/images/puzzle-1.jpg',
-          name: 'Cat',
           uuid: 'test-uuid-cat',
         ),
         localeNotifier: _makeLocaleNotifier(),


### PR DESCRIPTION
## Summary

Applying findings from a ponytail whole-repo audit. Net: **-73 lines, -1 dep**.

- **`uuid` dep removed** — 9 UUIDs were computed at runtime via v5 hash of static, never-changing paths. Hardcoded the same deterministic values as `const` strings. No user data migration needed (same UUID values).
- **`PuzzleImageData.name` deleted** — field was set for all 9 images but never read; l10n keys serve that role. Removed field, constructor param, and all 9 `name:` entries in tests.
- **8 `AppColors` legacy aliases removed** — `hotPink`, `green`, `greenShadow`, `orange`, `orangeShadow`, `blue`, `blueShadow`, `amber` all aliased canonical names. Updated all 10 call sites to use canonical names (`pastelPink`, `mintGreen`, `sunnyYellow`, `skyBlue`).
- **`StreakService._toDateString` simplified** — 3-line manual ISO-8601 formatter replaced with `dt.toIso8601String().split('T').first` (stdlib, 1 line).
- **`PuzzleBuilder` constructor** — `PuzzleBuilder._()` private constructor replaced with `abstract final class PuzzleBuilder` (idiomatic Dart).

## Test plan

- [x] `flutter test --no-pub` — 270 passing (up from 263), 8 failing (down from 10); all remaining failures are pre-existing `private-named-parameters` Dart 3.12 feature errors unrelated to these changes
- [x] `flutter analyze --no-pub` — 15 issues, all pre-existing `private-named-parameters` errors; zero new issues from this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)