### PR TITLE
Fix/migrate built in kotlin

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -2,7 +2,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     id("com.android.application")
-    id("org.jetbrains.kotlin.android")
 
     // The Flutter Gradle Plugin must be applied after the Android Gradle plugin.
     id("dev.flutter.flutter-gradle-plugin")

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -20,7 +20,6 @@ pluginManagement {
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
     id("com.android.application") version "9.2.1" apply false
-    id("org.jetbrains.kotlin.android") version "2.4.0" apply false
 }
 
 include(":app")


### PR DESCRIPTION
## Summary
- Remove the explicit `org.jetbrains.kotlin.android` plugin from the app module and settings, per Flutter's AGP 9 built-in Kotlin migration guide.
- Keep the existing `kotlin { compilerOptions { jvmTarget = JVM_17 } }` block so JVM target configuration is unchanged.

## Test plan
- [x] `flutter build apk --debug` succeeds
- [x] Original warning about applying the Kotlin Gradle Plugin in `android/app/build.gradle.kts` is no longer shown
- [x] `flutter test` — all 400 tests pass

## Notes
Flutter may still print a separate warning about the bundled Kotlin version (2.2.10) from AGP's built-in Kotlin support. That is unrelated to the KGP migration and will need a future Flutter/AGP update to resolve.

Made with [Cursor](https://cursor.com)