### PR TITLE
feat: Add opencode configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,12 @@ migrate_working_dir/
 !.cursor/commands
 !.cursor/agents
 
+# opencode: ignore local state, keep shared project config
+.opencode/*
+!.opencode/skills
+!.opencode/commands
+!.opencode/agents
+
 # The .vscode folder contains launch configuration and tasks you configure in
 # VS Code which you may wish to be included in version control, so this line
 # is commented out by default.

--- a/.opencode/agents
+++ b/.opencode/agents
@@ -1,0 +1,1 @@
+../.agents/agents

--- a/.opencode/commands
+++ b/.opencode/commands
@@ -1,0 +1,1 @@
+../.agents/commands

--- a/.opencode/skills
+++ b/.opencode/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "instructions": ["AGENTS.md"],
+  "shell": "/bin/bash",
+  "mcp": {
+    "android": {
+      "type": "local",
+      "command": ["bash", "tool/agents/android-mcp.sh"],
+      "enabled": true
+    }
+  },
+  "permission": {
+    "bash": {
+      "flutter test*": "allow",
+      "flutter analyze*": "allow",
+      "flutter build*": "allow",
+      "flutter run*": "allow",
+      "flutter pub get": "allow",
+      "flutter pub add*": "allow",
+      "adb*": "allow",
+      "git status*": "allow",
+      "git diff*": "allow",
+      "git log*": "allow",
+      "rm -rf*": "deny",
+      "*": "ask"
+    },
+    "external_directory": {
+      "~/.env": "deny",
+      "**/secrets/**": "deny",
+      "*": "allow"
+    }
+  }
+}

--- a/opencode.json
+++ b/opencode.json
@@ -11,6 +11,7 @@
   },
   "permission": {
     "bash": {
+      "*": "ask",
       "flutter test*": "allow",
       "flutter analyze*": "allow",
       "flutter build*": "allow",
@@ -21,13 +22,12 @@
       "git status*": "allow",
       "git diff*": "allow",
       "git log*": "allow",
-      "rm -rf*": "deny",
-      "*": "ask"
+      "rm -rf*": "deny"
     },
     "external_directory": {
+      "*": "allow",
       "~/.env": "deny",
-      "**/secrets/**": "deny",
-      "*": "allow"
+      "**/secrets/**": "deny"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Update `.gitignore` to properly track opencode skills, commands, and agents directories
- Add `.opencode/` directory with symlinks to shared `.agents/` configuration
- Add `opencode.json` project configuration with permissions and MCP setup

## Changes
- `.gitignore` - Added rules to ignore `.opencode/*` but preserve skills, commands, and agents
- `.opencode/agents` - Symlink to `.agents/agents`
- `.opencode/commands` - Symlink to `.agents/commands`
- `.opencode/skills` - Symlink to `.agents/skills`
- `opencode.json` - Project configuration for opencode CLI tool

## Notes
- Flutter tests could not be run in this environment (Flutter SDK not available)
- These are configuration-only changes with no impact on application code