### PR TITLE
chore: harden agent setup with hooks and two-phase code review

### DIFF
--- a/.agents/agents/code-reviewer.md
+++ b/.agents/agents/code-reviewer.md
@@ -4,33 +4,60 @@ description: |
   Senior code reviewer for this Flutter project. Use when completing a task, before opening a PR,
   after implementing a feature step, or when the user asks for code review. Compares changes
   against plans/specs and `.agents/review/criteria.md`. Compatible with superpowers
-  requesting-code-review workflow.
+  requesting-code-review workflow. Reviews in two phases: per-file, then cross-file connections.
 model: inherit
 readonly: true
 ---
 
 You are the project **code-reviewer** subagent for the Lily Jigsaw Puzzle Flutter app.
 
-Your job is to review a bounded git diff (or described change set) for production readiness.
+Your job is to review a bounded git change set for production readiness.
 You receive **only** the context in the dispatch prompt — not the parent session's history.
 
 ## Before reviewing
 
-1. Read `.agents/review/criteria.md` — this is the authoritative checklist.
-2. If a plan or spec is referenced, read it and verify the implementation matches.
-3. Run or inspect `git diff` for the provided `{BASE_SHA}..{HEAD_SHA}` range when SHAs are given.
+1. Read `.agents/review/criteria.md` — authoritative checklist and two-phase process.
+2. If a plan or spec is referenced, read it.
+3. Never run a full-range `git diff {BASE}..{HEAD}` into your context. That poisons attention on
+   large changes. Use name-only / per-path diffs only.
 
-## Review process
+## Phase selection
 
-1. **Plan / spec alignment** — all planned behaviour implemented? Unjustified deviations?
-2. **Code quality** — conventions, scope, naming, DRY/SOLID per criteria.
-3. **Testing** — new code tested? Edge cases? Constitution coverage gate respected?
-4. **Flutter / UI** — widget structure, state, mockup fidelity where UI changed.
-5. **Security** — secrets, validation, logging.
+The dispatch prompt sets `{PHASE}` to `per-file` or `connections`. Follow only that phase.
 
-## Output format
+### Phase: per-file
 
-Use this structure (same as superpowers `requesting-code-review`):
+1. List paths: `git diff --name-only {BASE_SHA}..{HEAD_SHA}` (and `--stat` if useful).
+2. For **each** path, in turn:
+   - Run `git diff {BASE_SHA}..{HEAD_SHA} -- <path>` only for that file.
+   - Check local correctness, style, security, and whether *this* file needs tests.
+   - Do not open other files’ diffs until you finish the current one.
+3. Output **only** a per-file notes list (no merge verdict yet):
+
+```
+## Per-file notes
+
+### path/to/file.dart
+- Strengths: …
+- Issues: [Critical|Important|Minor] file:line — what / why / fix
+```
+
+If only one file changed, still use this format.
+
+### Phase: connections
+
+You receive `{PER_FILE_NOTES}` from phase per-file. Do **not** re-fetch every file diff unless
+you need a specific line for a cross-file claim.
+
+1. From the file list + notes, check:
+   - Call sites / imports / public API contracts across changed files
+   - `lib/` changes have matching `test/` coverage (and vice versa)
+   - Shared models, constants, and theme usage stay consistent
+   - Plan/spec behaviour is covered by the *set* of files, not just locally
+2. Produce the final structured review (merge per-file issues with connection findings;
+   deduplicate).
+
+## Final output format (connections phase only)
 
 ### Strengths
 [Specific positives with file:line references]
@@ -38,13 +65,8 @@ Use this structure (same as superpowers `requesting-code-review`):
 ### Issues
 
 #### Critical (Must Fix)
-[Bugs, security, missing tests for new code, broken behaviour]
-
 #### Important (Should Fix)
-[Architecture, spec gaps, error handling, test gaps]
-
 #### Minor (Nice to Have)
-[Style, docs, small optimisations]
 
 For each issue: file:line, what's wrong, why it matters, how to fix.
 
@@ -57,7 +79,7 @@ For each issue: file:line, what's wrong, why it matters, how to fix.
 ## Rules
 
 - Categorise by actual severity — not everything is Critical.
-- Be specific (file:line). Never say "looks good" without checking the diff.
-- Acknowledge strengths before listing issues.
-- Give a clear verdict.
+- Be specific (file:line). Never say "looks good" without checking the relevant diff.
+- Acknowledge strengths before listing issues (connections phase).
+- Give a clear verdict (connections phase only).
 - Do **not** modify files — you are readonly.

--- a/.agents/commands/code-review.md
+++ b/.agents/commands/code-review.md
@@ -1,28 +1,36 @@
 ---
-description: Dispatch the project code-reviewer subagent for the current branch changes.
+description: Dispatch the project code-reviewer subagent for the current branch changes (per-file, then connections).
 ---
 
 # Code review
 
-Dispatch the **`code-reviewer`** subagent to review changes before opening a PR.
+Dispatch the **`code-reviewer`** subagent in **two phases** before opening a PR.
+Do not review the full-range diff in one shot.
 
 ## Steps
 
-1. Determine the git range:
+1. Determine the git range and file list:
    ```bash
    BASE_SHA=$(git merge-base HEAD origin/main)
    HEAD_SHA=$(git rev-parse HEAD)
+   git diff --name-only "$BASE_SHA".."$HEAD_SHA"
    git diff --stat "$BASE_SHA".."$HEAD_SHA"
    ```
 
-2. Read `.agents/review/dispatch-template.md` and fill in:
+2. Read `.agents/review/dispatch-template.md` and fill placeholders:
    - `{DESCRIPTION}` — summarise what changed (or use `$ARGUMENTS` if the user provided context)
    - `{PLAN_OR_REQUIREMENTS}` — relevant spec/plan path, or "general maintenance" if none
-   - `{BASE_SHA}` / `{HEAD_SHA}`
+   - `{BASE_SHA}` / `{HEAD_SHA}` / `{CHANGED_FILES}`
 
-3. Launch Task tool with `subagent_type: code-reviewer`, `readonly: true`, and the filled prompt.
+3. **Phase per-file:** Launch Task with `subagent_type: code-reviewer`,
+   `{PHASE}` = `per-file`, `{PER_FILE_NOTES}` = `n/a`. Keep the Per-file notes.
 
-4. Present the subagent's structured review (Strengths / Issues / Assessment) to the user.
+4. **Phase connections:** Launch a second Task with `subagent_type: code-reviewer`,
+   `{PHASE}` = `connections`, `{PER_FILE_NOTES}` = phase-1 output.
+   The subagent is readonly (frontmatter) — do not ask it to edit files.
+
+5. Present the connections-phase review (Strengths / Issues / Assessment) to the user.
+   Optionally attach a short summary of per-file notes if useful.
 
 User input (optional):
 

--- a/.agents/review/criteria.md
+++ b/.agents/review/criteria.md
@@ -4,6 +4,17 @@ Shared checklist for the `code-reviewer` subagent (local/superpowers) and the
 `.github/workflows/cursor-code-review.yml` CI agent. Keep this file as the single source of
 review standards.
 
+## Review process (two-phase)
+
+Do **not** load the full range diff into context in one shot. That dilutes attention on large
+changes. Always use two phases:
+
+1. **Per-file** — list changed paths, then review each file’s own diff in isolation
+   (`git diff {BASE}..{HEAD} -- <path>`). Note local bugs, style, missing tests for that file.
+2. **Connections** — with per-file notes only (not the full mega-diff), check how changes fit
+   together: call sites, imports/APIs, `lib/` ↔ `test/` pairing, shared types, plan/spec
+   coverage across files.
+
 ## Project standards (always check)
 
 Read before reviewing:

--- a/.agents/review/dispatch-template.md
+++ b/.agents/review/dispatch-template.md
@@ -1,10 +1,34 @@
-# Code review dispatch template
+# Code review dispatch templates
 
-Fill this template when dispatching the `code-reviewer` subagent (via superpowers
-`requesting-code-review` skill, `/code-review` command, or Task tool).
+Fill these when dispatching the `code-reviewer` subagent (via `requesting-code-review` skill,
+`/code-review` command, or Task tool).
+
+Always run **two Task launches** (fresh context each time):
+
+1. **per-file** — template below with `{PHASE}` = `per-file`
+2. **connections** — template below with `{PHASE}` = `connections` and `{PER_FILE_NOTES}` =
+   the phase-1 output
+
+Do **not** paste a full-range `git diff` into the prompt.
+
+**Getting SHAs:**
+
+```bash
+BASE_SHA=$(git merge-base HEAD origin/main)   # or explicit base
+HEAD_SHA=$(git rev-parse HEAD)
+git diff --name-only "$BASE_SHA".."$HEAD_SHA"
+```
+
+---
+
+## Shared prompt body
 
 ```
 Review the following change for production readiness.
+
+## Phase
+
+{PHASE}
 
 ## What was implemented
 
@@ -19,24 +43,32 @@ Review the following change for production readiness.
 Base: {BASE_SHA}
 Head: {HEAD_SHA}
 
-Run:
-  git diff --stat {BASE_SHA}..{HEAD_SHA}
-  git diff {BASE_SHA}..{HEAD_SHA}
+## Changed files (name-only)
+
+{CHANGED_FILES}
+
+## Per-file notes (connections phase only)
+
+{PER_FILE_NOTES}
 
 ## Instructions
 
-Follow `.agents/review/criteria.md` for project standards.
+Follow `.agents/review/criteria.md`.
 
-Structure your response as:
-
-### Strengths
-### Issues (Critical / Important / Minor — with file:line)
-### Assessment (Ready to merge? Yes / With fixes / No)
+- If phase is `per-file`: review each path with
+  `git diff {BASE_SHA}..{HEAD_SHA} -- <path>` only. Never dump the full-range diff.
+  Return ## Per-file notes only (no Assessment).
+- If phase is `connections`: use {PER_FILE_NOTES} and the file list. Fetch individual file
+  diffs only when needed to verify a cross-file claim. Return Strengths / Issues / Assessment.
 ```
 
-**Getting SHAs:**
+Placeholders:
 
-```bash
-BASE_SHA=$(git merge-base HEAD origin/main)   # or explicit base
-HEAD_SHA=$(git rev-parse HEAD)
-```
+| Placeholder | Fill with |
+|---|---|
+| `{PHASE}` | `per-file` or `connections` |
+| `{DESCRIPTION}` | What changed |
+| `{PLAN_OR_REQUIREMENTS}` | Spec/plan path, or `general maintenance` |
+| `{BASE_SHA}` / `{HEAD_SHA}` | Git range |
+| `{CHANGED_FILES}` | Output of `git diff --name-only …` |
+| `{PER_FILE_NOTES}` | Phase-1 output, or `n/a` for per-file phase |

--- a/.agents/skills/pr-workflow/SKILL.md
+++ b/.agents/skills/pr-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-workflow
-description: Pre-push verification, pull request creation, and CI watch loop. Use when committing, pushing, opening a PR, or fixing failing CI checks on a branch.
+description: Pre-push verification and pull request creation. Use when committing, pushing, or opening a PR. Use when the user asks to fix failing CI on a branch.
 ---
 
 # PR workflow
@@ -12,25 +12,17 @@ description: Pre-push verification, pull request creation, and CI watch loop. Us
 3. Verify test coverage has not dropped.
 4. Only open a PR once all of the above pass cleanly.
 
-## After opening a PR — CI watch loop
+## After opening a PR
 
-After creating a PR, poll CI status using `gh` until checks complete:
+Stop once the PR exists and share the URL. Do **not** poll or watch CI.
 
-```bash
-# Wait for all checks to finish (polls every 30s)
-gh pr checks --watch
+A human stays in the loop; if CI fails, they will ask separately to investigate and fix.
 
-# If any check fails, read the logs:
-gh run list --branch <branch> --limit 1
-gh run view <run-id> --log-failed
-```
+When asked to fix CI:
 
-If checks fail:
-
-1. Read the failure output carefully
+1. Read the failure output (`gh pr checks`, `gh run view --log-failed`)
 2. Fix the root cause in the source code
-3. Commit and push the fix to the same branch
-4. Repeat until `gh pr checks --watch` exits with all green
+3. Commit and push to the same branch
 
 ## CI/CD context
 

--- a/.agents/skills/requesting-code-review/SKILL.md
+++ b/.agents/skills/requesting-code-review/SKILL.md
@@ -1,12 +1,15 @@
 ---
 name: requesting-code-review
-description: Use when completing tasks, implementing major features, or before merging to verify work meets requirements. Dispatches the project code-reviewer subagent with isolated context.
+description: Use when completing tasks, implementing major features, or before merging to verify work meets requirements. Dispatches the project code-reviewer subagent with isolated context in two phases (per-file, then connections).
 ---
 
 # Requesting code review
 
 Review early, review often. Dispatch the project **`code-reviewer`** subagent — it gets a crafted
 prompt with the git range and requirements, not your session history.
+
+Large diffs poison attention if reviewed in one blob. Always use **two Task launches**:
+per-file scan, then cross-file connections (see `.agents/review/dispatch-template.md`).
 
 Works with the [superpowers](https://github.com/obra/superpowers) plugin: this project skill
 overrides the generic flow with Flutter-specific criteria at `.agents/review/criteria.md`.
@@ -18,32 +21,42 @@ overrides the generic flow with Flutter-specific criteria at `.agents/review/cri
 - Before opening a PR
 - When stuck and you want a fresh perspective
 
-## How to dispatch
+## How to dispatch (two-phase)
 
-**1. Get git SHAs:**
+**1. Get git SHAs and the file list:**
 
 ```bash
 BASE_SHA=$(git merge-base HEAD origin/main)
 HEAD_SHA=$(git rev-parse HEAD)
+git diff --name-only "$BASE_SHA".."$HEAD_SHA"
 ```
 
-**2. Build the prompt** from `.agents/review/dispatch-template.md` with:
+**2. Phase — per-file**
 
+Build the prompt from `.agents/review/dispatch-template.md` with:
+
+- `{PHASE}` = `per-file`
 - `{DESCRIPTION}` — what you implemented
 - `{PLAN_OR_REQUIREMENTS}` — spec, plan path, or acceptance criteria
-- `{BASE_SHA}` / `{HEAD_SHA}`
+- `{BASE_SHA}` / `{HEAD_SHA}` / `{CHANGED_FILES}`
+- `{PER_FILE_NOTES}` = `n/a`
 
-**3. Launch the subagent:**
+Launch Task with `subagent_type: code-reviewer` and that prompt.
+Save the returned **Per-file notes**.
 
-Use the Task tool with:
+**3. Phase — connections**
 
-- `subagent_type`: `code-reviewer`
-- `readonly`: `true`
-- `prompt`: filled template from step 2
+Build the same template with:
+
+- `{PHASE}` = `connections`
+- `{PER_FILE_NOTES}` = phase-1 output (do not paste full diffs)
+
+Launch a **second** Task with `subagent_type: code-reviewer`.
+The subagent is readonly (frontmatter) — do not ask it to edit files.
 
 Or invoke `/code-review` if you prefer an explicit command entry point.
 
-**4. Act on feedback:**
+**4. Act on feedback** (from the connections-phase Assessment):
 
 - Fix Critical issues immediately
 - Fix Important issues before proceeding

--- a/.agents/skills/speckit-agent-context-update/SKILL.md
+++ b/.agents/skills/speckit-agent-context-update/SKILL.md
@@ -1,10 +1,12 @@
 ---
 name: speckit-agent-context-update
-description: Refresh the managed Spec Kit section in the coding agent context file
+description: Refresh the managed Spec Kit section in the coding agent context file (AGENTS.md / CLAUDE.md). Use after planning a feature, when the active specs/*/plan.md changes, or when Spec Kit markers are missing or stale.
 compatibility: Requires spec-kit project structure with .specify/ directory
 metadata:
   author: github-spec-kit
   source: agent-context:commands/speckit.agent-context.update.md
+user-invocable: true
+disable-model-invocation: false
 ---
 
 # Update Coding Agent Context

--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "hooks": {
+    "afterFileEdit": [
+      {
+        "command": ".cursor/hooks/dart-format.sh"
+      }
+    ]
+  }
+}

--- a/.cursor/hooks/dart-format.sh
+++ b/.cursor/hooks/dart-format.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Format Dart files after Agent edits. Fail-open: never block the agent.
+set -u
+
+input=$(cat)
+
+file_path=$(python3 -c '
+import json, sys
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+path = data.get("file_path") or ""
+print(path)
+' <<<"$input" 2>/dev/null || true)
+
+if [[ -z "${file_path}" || "${file_path}" != *.dart ]]; then
+  exit 0
+fi
+
+if [[ ! -f "${file_path}" ]]; then
+  exit 0
+fi
+
+if ! command -v dart >/dev/null 2>&1; then
+  exit 0
+fi
+
+dart format "${file_path}" >/dev/null 2>&1 || true
+exit 0

--- a/.cursor/rules/specify-rules.mdc
+++ b/.cursor/rules/specify-rules.mdc
@@ -1,0 +1,8 @@
+---
+alwaysApply: true
+---
+
+<!-- SPECKIT START -->
+For additional context about technologies to be used, project structure,
+shell commands, and other important information, read the current plan
+<!-- SPECKIT END -->

--- a/.cursor/skills
+++ b/.cursor/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.github/cursor/prompts/review.md
+++ b/.github/cursor/prompts/review.md
@@ -56,13 +56,36 @@ gh api repos/${REPO}/issues/${PR_NUMBER}/comments \
   --jq '[.[] | select(.user.type == "Bot" or (.performed_via_github_app != null)) | {id, body}]'
 ```
 
-## Step 2 — Fetch and parse the current diff
+## Step 2 — Two-phase review (avoid loading the full diff at once)
+
+Follow `.agents/review/criteria.md` **Review process (two-phase)**. Do not dump the entire PR
+diff into context in one shot.
+
+**2a — Per-file**
 
 ```bash
-gh pr diff ${PR_NUMBER}
+git diff --name-only ${PR_BASE_SHA}..${PR_HEAD_SHA}
 ```
 
-Build a CHANGED_LINES map: for every + line in the diff record its file path and line number. Only + lines are reviewable.
+For each changed path, fetch that file’s diff only:
+
+```bash
+git diff ${PR_BASE_SHA}..${PR_HEAD_SHA} -- <path>
+```
+
+Review the file in isolation and keep short per-file notes (strengths + issues with path:line).
+Do not open the next file’s diff until the current one is done. Do **not** run
+`gh pr diff` / a full-range `git diff` without a path filter.
+
+**2b — Connections**
+
+Using the per-file notes and the file list (not a fresh full-range mega-diff), check cross-file
+links: call sites, imports/APIs, `lib/` ↔ `test/` pairing, shared types, and whether the set of
+files covers the intended behaviour. Re-fetch an individual file diff only when needed to verify
+a cross-file claim.
+
+Build a CHANGED_LINES map from the per-file diffs: for every + line record its file path and line
+number. Only + lines are reviewable.
 
 ## Step 3 — Reconcile prior inline comment threads
 

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,12 @@ migrate_working_dir/
 !.cursor/mcp.json
 !.cursor/commands
 !.cursor/agents
+!.cursor/skills
+!.cursor/hooks.json
+!.cursor/hooks/
+!.cursor/hooks/**
+!.cursor/rules/
+!.cursor/rules/**
 
 # opencode: ignore local state, keep shared project config
 .opencode/*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,13 +105,13 @@ files only — adapter paths are symlinks and must not be edited directly.
 | Canonical (edit these) | Adapter (symlink — do not edit) |
 |---|---|
 | `AGENTS.md` | `CLAUDE.md` → `AGENTS.md` |
-| `.agents/skills/` | `.claude/skills` → `.agents/skills` |
+| `.agents/skills/` | `.claude/skills`, `.cursor/skills` → `.agents/skills` |
 | `.agents/commands/` | `.claude/commands`, `.cursor/commands` → `.agents/commands` |
 | `.agents/agents/` | `.claude/agents`, `.cursor/agents` → `.agents/agents` |
 | `.mcp.json` | `.cursor/mcp.json` → `.mcp.json` |
 
-Cursor reads `.agents/skills/` natively; Claude Code and Cursor reach commands, agents, and MCP
-via the adapter symlinks above.
+Edit skills only under `.agents/skills/`. Claude Code and Cursor reach skills, commands, agents,
+and MCP via the adapter symlinks above.
 
 Spec Kit: both `claude` and `cursor-agent` integrations are installed (`.specify/integration.json`);
 default CLI integration is `cursor-agent`. Skills and agent-context target canonical `.agents/` paths.


### PR DESCRIPTION
## Summary
- Share Cursor skills via `.cursor/skills` → `.agents/skills` symlink; track shared hooks/rules in `.gitignore`
- Add `afterFileEdit` dart-format hook and sync Spec Kit always-on rule with AGENTS
- Split local/CI code review into per-file then connections phases so large diffs stay focused

## Test plan
- [x] `flutter analyze` — no issues
- [x] `flutter test` — all passed
- [ ] Confirm Cursor loads `.cursor/skills` symlink and runs dart-format hook after a Dart edit
- [ ] Run `/code-review` and confirm two Task launches (per-file notes, then Assessment)


Made with [Cursor](https://cursor.com)